### PR TITLE
[ Login ] 로그인 유무에 따른 페이지 이동 구성 및 헤더 변경

### DIFF
--- a/nonsoolmateClient/src/components/onbordingheader/HeaderLeft.tsx
+++ b/nonsoolmateClient/src/components/onbordingheader/HeaderLeft.tsx
@@ -1,11 +1,13 @@
 import { LogoIc } from "@assets/index";
+import useGetName from "home/hooks/useGetName";
 import { useNavigate } from "react-router";
 import styled from "styled-components";
 
 export default function HeaderLeft() {
   const navigate = useNavigate();
+  const getNameResponse = useGetName();
   return (
-    <LogoContainer type="button" onClick={() => navigate("/")}>
+    <LogoContainer type="button" onClick={() => (getNameResponse ? navigate("/home/test") : navigate("/"))}>
       <LogoIcon />
     </LogoContainer>
   );

--- a/nonsoolmateClient/src/home/components/HomeHeader.tsx
+++ b/nonsoolmateClient/src/home/components/HomeHeader.tsx
@@ -23,7 +23,7 @@ export default function HomeHeader() {
   return (
     <>
       <Header>
-        <LogoButton onClick={() => navigate("/")} type="button">
+        <LogoButton onClick={() => (getNameResponse ? navigate("/home/test") : navigate("/"))} type="button">
           <LogoIcon />
         </LogoButton>
         <HeaderInfo>

--- a/nonsoolmateClient/src/membership/index.tsx
+++ b/nonsoolmateClient/src/membership/index.tsx
@@ -1,13 +1,16 @@
 import Header from "@components/onbordingheader/Header";
-import { columnFlex } from "style/commonStyle";
 import styled from "styled-components";
 import Contents from "./components/Contents";
 import Title from "./components/Title";
+import useGetName from "home/hooks/useGetName";
+import HomeHeader from "home/components/HomeHeader";
 
 export default function Membership() {
+  const getNameResponse = useGetName();
+
   return (
     <Container>
-      <Header isOnboarding={false} />
+      {getNameResponse ? <HomeHeader /> : <Header isOnboarding={false} />}
       <Title />
       <Contents />
     </Container>
@@ -15,7 +18,5 @@ export default function Membership() {
 }
 
 const Container = styled.section`
-  ${columnFlex}
-
   position: relative;
 `;

--- a/nonsoolmateClient/src/signup/components/login/SignupButton.tsx
+++ b/nonsoolmateClient/src/signup/components/login/SignupButton.tsx
@@ -1,7 +1,15 @@
+import { redirectToNaverAuth } from "socialLogin/utils/redirectToNaverAuth";
 import styled from "styled-components";
 
 export default function SignupButton() {
-  return <Button type="button">네이버로 회원가입하기</Button>;
+  function loginHandler() {
+    redirectToNaverAuth();
+  }
+  return (
+    <Button onClick={loginHandler} type="button">
+      네이버로 회원가입하기
+    </Button>
+  );
 }
 
 const Button = styled.button`


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #8 

## 📝 Done Task
- [x] 로그인 유무에 따라 멤버십 화면 헤더 다르게 구현
- [x] 로그인 유무에 따라 헤더에 nonsoolmate 아이콘 클릭 시 페이지 이동 다르게 되도록 구현 
