### PR TITLE
[ OnBoarding ] 로그인 시 내 정보 보이도록 온보딩 헤더 수정 및 미로그인시 뜨는 403 에러 해결

### DIFF
--- a/nonsoolmateClient/src/components/onbordingheader/Header.tsx
+++ b/nonsoolmateClient/src/components/onbordingheader/Header.tsx
@@ -2,6 +2,8 @@ import { commonFlex } from "style/commonStyle";
 import HeaderLeft from "./HeaderLeft";
 import HeaderRight from "./HeaderRight";
 import styled from "styled-components";
+import HomeMemberInfoToggle from "home/components/HomeMemberInfoToggle";
+import { useState } from "react";
 
 interface HeaderProps {
   isOnboarding: boolean;
@@ -9,14 +11,21 @@ interface HeaderProps {
 
 export default function Header(props: HeaderProps) {
   const { isOnboarding } = props;
+  const [showMemberInfo, setShowMemberInfo] = useState<boolean>(false);
 
+  function handleHomeMemberInfoToggle() {
+    setShowMemberInfo((open) => !open);
+  }
   return (
-    <Container $isOnboarding={isOnboarding}>
-      <ContentContainer>
-        <HeaderLeft />
-        <HeaderRight />
-      </ContentContainer>
-    </Container>
+    <>
+      <Container $isOnboarding={isOnboarding}>
+        <ContentContainer>
+          <HeaderLeft />
+          <HeaderRight handleHomeMemberInfoToggle={handleHomeMemberInfoToggle} showMemberInfo={showMemberInfo} />
+        </ContentContainer>
+      </Container>
+      {showMemberInfo && <HomeMemberInfoToggle />}
+    </>
   );
 }
 const Container = styled.header<{ $isOnboarding: boolean }>`

--- a/nonsoolmateClient/src/components/onbordingheader/HeaderLeft.tsx
+++ b/nonsoolmateClient/src/components/onbordingheader/HeaderLeft.tsx
@@ -1,11 +1,13 @@
 import { LogoIc } from "@assets/index";
 import useGetName from "home/hooks/useGetName";
 import { useNavigate } from "react-router";
+import { getToken } from "socialLogin/utils/token";
 import styled from "styled-components";
 
 export default function HeaderLeft() {
   const navigate = useNavigate();
-  const getNameResponse = useGetName();
+  const token = getToken();
+  const getNameResponse = token ? useGetName() : null;
   return (
     <LogoContainer type="button" onClick={() => (getNameResponse ? navigate("/home/test") : navigate("/"))}>
       <LogoIcon />

--- a/nonsoolmateClient/src/components/onbordingheader/HeaderRight.tsx
+++ b/nonsoolmateClient/src/components/onbordingheader/HeaderRight.tsx
@@ -2,12 +2,42 @@ import styled from "styled-components";
 import LoginButton from "./buttons/LoginButton";
 import MembershipButton from "./buttons/MembershipButton";
 import { commonFlex } from "style/commonStyle";
+import useGetName from "home/hooks/useGetName";
+import { DownArrowGreyIc, LoginInfoIc, UpArrowGreyIc } from "@assets/index";
+import { getToken } from "socialLogin/utils/token";
 
-export default function HeaderRight() {
+interface HeaderRightProps {
+  handleHomeMemberInfoToggle: () => void;
+  showMemberInfo: boolean;
+}
+export default function HeaderRight(props: HeaderRightProps) {
+  const { handleHomeMemberInfoToggle, showMemberInfo } = props;
+  const token = getToken();
+  const getNameResponse = token ? useGetName() : null;
+  if (!getNameResponse)
+    return (
+      <Container>
+        <MembershipButton />
+        <LoginButton />
+      </Container>
+    );
+
+  const {
+    data: { memberName },
+  } = getNameResponse;
+
   return (
     <Container>
       <MembershipButton />
-      <LoginButton />
+      {getNameResponse && (
+        <LoginInfoButton type="button" onClick={handleHomeMemberInfoToggle}>
+          <LoginInfoIcon />
+          <LoginInfoBox>
+            <LoginId>{memberName} 님</LoginId>
+            {showMemberInfo ? <UpArrowGreyIcon /> : <DownArrowGreyIcon />}
+          </LoginInfoBox>
+        </LoginInfoButton>
+      )}
     </Container>
   );
 }
@@ -15,7 +45,44 @@ export default function HeaderRight() {
 const Container = styled.div`
   ${commonFlex}
 
-  justify-content: space-between;
+  gap: 1.6rem;
+  flex: 1;
+  justify-content: end;
   width: 16.2rem;
   height: 3.2rem;
+`;
+const LoginInfoButton = styled.button`
+  ${commonFlex};
+
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0;
+  cursor: pointer;
+`;
+const LoginInfoIcon = styled(LoginInfoIc)`
+  object-fit: cover;
+`;
+const LoginInfoBox = styled.section`
+  ${commonFlex};
+
+  gap: 0.8rem;
+  padding: 0.4rem 0;
+`;
+
+const LoginId = styled.h1`
+  ${({ theme }) => theme.fonts.Body3};
+
+  color: ${({ theme }) => theme.colors.grey_700};
+`;
+
+const DownArrowGreyIcon = styled(DownArrowGreyIc)`
+  object-fit: cover;
+  width: 2.4rem;
+  height: 2.4rem;
+`;
+
+const UpArrowGreyIcon = styled(UpArrowGreyIc)`
+  object-fit: cover;
+  width: 2.4rem;
+  height: 2.4rem;
 `;

--- a/nonsoolmateClient/src/membership/index.tsx
+++ b/nonsoolmateClient/src/membership/index.tsx
@@ -4,9 +4,11 @@ import Contents from "./components/Contents";
 import Title from "./components/Title";
 import useGetName from "home/hooks/useGetName";
 import HomeHeader from "home/components/HomeHeader";
+import { getToken } from "socialLogin/utils/token";
 
 export default function Membership() {
-  const getNameResponse = useGetName();
+  const token = getToken();
+  const getNameResponse = token ? useGetName() : null;
 
   return (
     <Container>


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #14 

## 📝 Done Task
- [x] 로그인 시 내 정보 보이도록 온보딩 헤더 수정
- [x] 미로그인 시에도 get 요청을 보내서 뜨는 403 에러 해결(토큰 확인 후 토큰이 있을 때만 get 요청 보내도록 수정) 

## 🔎 PR Point
<!-- 리뷰어에게 내 코드를 설명해주세요. -->
이전에 혜인언니는 온보딩 헤더를 그냥 홈 헤더랑 구분이 되게 따로 코드를 짜놨더라구용..? 둘이 하는 역할은 어차피 같은 것 같아서 나중에 보고 하나로 통일하면 좋을 것 같아요!!