### PR TITLE
[ TakeTest ] 제출하기 버튼 중복 클릭 방지

### DIFF
--- a/nonsoolmateClient/src/takeTest/components/modal/TestSubmitModal.tsx
+++ b/nonsoolmateClient/src/takeTest/components/modal/TestSubmitModal.tsx
@@ -7,6 +7,7 @@ import { usePutExamSheet } from "takeTest/hooks/usePutExamSheet";
 import Error from "error";
 import { usePostExamRecord } from "takeTest/hooks/usePostExamRecord";
 import { getPresignedUrl } from "takeTest/api/getPresignedUrl";
+import { useRef } from "react";
 
 interface TestSubmitProps {
   isFile: File[] | null;
@@ -22,8 +23,12 @@ export default function TestSubmitModal(props: TestSubmitProps) {
   let zip = new JSZip();
   const location = useLocation();
   const { examId } = location.state;
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   async function handleZipCreation() {
+    if (buttonRef.current) {
+      buttonRef.current.disabled = true;
+    }
     const response = await getPresignedUrl();
     if (!response) return <Error />;
 
@@ -83,7 +88,7 @@ export default function TestSubmitModal(props: TestSubmitProps) {
         <ModalContent>
           <ModalTitle>아래 파일을 제출하시겠습니까?</ModalTitle>
           <ModalFile>{isFile?.map((item) => <FileName key={item.name}>{item.name}</FileName>)}</ModalFile>
-          <SubmitButton onClick={handleZipCreation} type="button">
+          <SubmitButton onClick={handleZipCreation} type="button" ref={buttonRef}>
             제출하기
           </SubmitButton>
         </ModalContent>


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #61 

## 📝 Done Task
- [x] useRef를 사용해서 한번 클릭하고 나면 disabled=true를 주어 중복제출 막는

```js
  async function handleZipCreation() {
    if (buttonRef.current) {
      buttonRef.current.disabled = true;
    }
```

‼️ 타입에러
- buttonRef 타입에 `useRef<HTMLButtonElement>`를 함으로써 button element임을 명시

## 📸 Screenshot

