### PR TITLE
[Mypage] 아이패드 반응형 구현

### DIFF
--- a/nonsoolmateClient/src/home/components/HomeMemberInfoToggle.tsx
+++ b/nonsoolmateClient/src/home/components/HomeMemberInfoToggle.tsx
@@ -53,6 +53,7 @@ const MemberInfoToggleView = styled.section`
   position: absolute;
   top: 0.8rem;
   right: 21.5rem;
+  z-index: 1;
   width: 22.8rem;
   height: 17rem;
   padding: 2rem 2.4rem;

--- a/nonsoolmateClient/src/mypage/components/IpadMypageSide.tsx
+++ b/nonsoolmateClient/src/mypage/components/IpadMypageSide.tsx
@@ -1,0 +1,69 @@
+import styled from "styled-components";
+
+interface IpadMypageSideProps {
+  handleInfo: () => void;
+  handleSecond: () => void;
+  handleThird: () => void;
+  isClicked: number;
+}
+
+export default function IpadMypageSide(props: IpadMypageSideProps) {
+  const { handleInfo, handleSecond, handleThird, isClicked } = props;
+  return (
+    <Container>
+      <Header>마이페이지</Header>
+      <Sidebar>
+        <Btn type="button" $isClicked={isClicked === 1} onClick={handleInfo}>
+          회원정보
+        </Btn>
+        <Btn type="button" $isClicked={isClicked === 2} onClick={handleSecond}>
+          다른메뉴
+        </Btn>
+        <Btn type="button" $isClicked={isClicked === 3} onClick={handleThird}>
+          또다른메뉴
+        </Btn>
+      </Sidebar>
+      {/* <Border /> */}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+  padding: 0 3.2rem;
+`;
+
+const Header = styled.h2`
+  margin-top: 3.2rem;
+  margin-bottom: 2.4rem;
+
+  ${({ theme }) => theme.fonts.Headline5};
+
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+const Sidebar = styled.aside`
+  display: flex;
+  gap: 4rem;
+  width: 100%;
+`;
+
+const Btn = styled.button<{ $isClicked: boolean }>`
+  padding: 0 0 0.5rem;
+  border: none;
+  border-bottom: ${({ $isClicked }) => ($isClicked ? "1px solid black" : "none")};
+  color: ${({ theme, $isClicked }) => ($isClicked ? theme.colors.black : theme.colors.grey_400)};
+  cursor: pointer;
+  ${({ theme }) => theme.fonts.Body5};
+`;
+
+const Border = styled.div`
+  position: absolute;
+  top: 10.9rem;
+  z-index: 0;
+  width: 100%;
+  border-bottom: 1px solid var(--grayscale-gray200, #e2e4e8);
+`;

--- a/nonsoolmateClient/src/mypage/components/IpadMypageSide.tsx
+++ b/nonsoolmateClient/src/mypage/components/IpadMypageSide.tsx
@@ -23,7 +23,6 @@ export default function IpadMypageSide(props: IpadMypageSideProps) {
           또다른메뉴
         </Btn>
       </Sidebar>
-      {/* <Border /> */}
     </Container>
   );
 }
@@ -58,12 +57,4 @@ const Btn = styled.button<{ $isClicked: boolean }>`
   color: ${({ theme, $isClicked }) => ($isClicked ? theme.colors.black : theme.colors.grey_400)};
   cursor: pointer;
   ${({ theme }) => theme.fonts.Body5};
-`;
-
-const Border = styled.div`
-  position: absolute;
-  top: 10.9rem;
-  z-index: 0;
-  width: 100%;
-  border-bottom: 1px solid var(--grayscale-gray200, #e2e4e8);
 `;

--- a/nonsoolmateClient/src/mypage/components/MemberInfo.tsx
+++ b/nonsoolmateClient/src/mypage/components/MemberInfo.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import useGetProfile from "mypage/hooks/useGetProfile";
+import { media } from "style/responsiveStyle";
 
 export default function MemberInfo() {
   const response = useGetProfile();
@@ -38,39 +39,57 @@ const MemberInfoContainer = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 2.8rem;
+  position: relative;
   width: 100%;
   padding: 8rem 6.4rem;
+
+  ${media.tablet} {
+    padding: 3.1rem 3.2rem;
+  }
 `;
+
 const Info = styled.li`
   display: flex;
   gap: 0.2rem;
-  position: relative;
   width: 65rem;
 `;
+
 const Title = styled.p`
   ${({ theme }) => theme.fonts.Body3};
 
   width: 8.8rem;
 `;
+
 const Text = styled.p`
   ${({ theme }) => theme.fonts.Body4};
 `;
+
 const ReviseButton = styled.button`
   ${({ theme }) => theme.fonts.Body4};
 
   position: absolute;
-  right: 0;
+  right: 22.5rem;
   width: 7.6rem;
   color: ${({ theme }) => theme.colors.main_blue};
+
+  ${media.tablet} {
+    right: 3.2rem;
+  }
 `;
+
 const GenderBox = styled.ul`
   ${({ theme }) => theme.fonts.Body7};
 
   display: flex;
   gap: 0.6rem;
   position: absolute;
-  right: 26rem;
+  right: 48.4rem;
+
+  ${media.tablet} {
+    right: 3.2rem;
+  }
 `;
+
 const Male = styled.li<{ $gender: String }>`
   padding: 0.4rem 0.8rem;
   border: 1px solid ${({ $gender, theme }) => ($gender == "M" ? theme.colors.main_blue : theme.colors.grey_400)};
@@ -78,6 +97,7 @@ const Male = styled.li<{ $gender: String }>`
   background-color: ${({ $gender, theme }) => ($gender == "M" ? theme.colors.light_blue : theme.colors.grey_50)};
   color: ${({ $gender, theme }) => ($gender == "M" ? theme.colors.main_blue : theme.colors.grey_400)};
 `;
+
 const Female = styled.li<{ $gender: String }>`
   padding: 0.4rem 0.8rem;
   border: 1px solid ${({ $gender, theme }) => ($gender == "F" ? theme.colors.main_blue : theme.colors.grey_400)};

--- a/nonsoolmateClient/src/mypage/components/MemberInfo.tsx
+++ b/nonsoolmateClient/src/mypage/components/MemberInfo.tsx
@@ -41,7 +41,7 @@ const MemberInfoContainer = styled.ul`
   gap: 2.8rem;
   position: relative;
   width: 100%;
-  padding: 8rem 6.4rem;
+  padding: 8rem 0 8rem 6.4rem;
 
   ${media.tablet} {
     padding: 3.1rem 3.2rem;
@@ -51,7 +51,6 @@ const MemberInfoContainer = styled.ul`
 const Info = styled.li`
   display: flex;
   gap: 0.2rem;
-  width: 65rem;
 `;
 
 const Title = styled.p`
@@ -83,7 +82,7 @@ const GenderBox = styled.ul`
   display: flex;
   gap: 0.6rem;
   position: absolute;
-  right: 48.4rem;
+  right: 50rem;
 
   ${media.tablet} {
     right: 3.2rem;

--- a/nonsoolmateClient/src/mypage/index.tsx
+++ b/nonsoolmateClient/src/mypage/index.tsx
@@ -2,27 +2,59 @@ import HomeHeader from "home/components/HomeHeader";
 import styled from "styled-components";
 import MypageSide from "./components/MypageSide";
 import MemberInfo from "./components/MemberInfo";
+import { useMediaQuery } from "react-responsive";
+import { media } from "style/responsiveStyle";
+import IpadMypageSide from "./components/IpadMypageSide";
+import { useState } from "react";
 
 export default function index() {
+  const isIpadSize = useMediaQuery({ query: "(max-width: 1024px)" });
+  const [isClicked, setIsClicked] = useState<number>(1);
+
+  function handleInfo() {
+    setIsClicked(1);
+  }
+
+  function handleSecond() {
+    setIsClicked(2);
+  }
+
+  function handleThird() {
+    setIsClicked(3);
+  }
+
   return (
     <MypageContainer>
       <HomeHeader />
       <Mypage>
-        <MypageSide />
-        <MemberInfo />
+        {!isIpadSize && <MypageSide />}
+        {isIpadSize && (
+          <IpadMypageSide
+            isClicked={isClicked}
+            handleInfo={handleInfo}
+            handleSecond={handleSecond}
+            handleThird={handleThird}
+          />
+        )}
+        {(!isIpadSize || isClicked === 1) && <MemberInfo />}
       </Mypage>
     </MypageContainer>
   );
 }
+
 const MypageContainer = styled.section`
   display: flex;
   flex-direction: column;
   width: 100%;
   height: 100vh;
 `;
+
 const Mypage = styled.div`
   display: flex;
-  flex-direction: row;
   width: 100%;
   height: 100vh;
+
+  ${media.tablet} {
+    flex-direction: column;
+  }
 `;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #56 

## 📝 Done Task
- [x] 마이페이지 아이패드 반응형 구현 
   - 회원정보를 눌렀을때만 MemberInfo가 나오도록 `isClicked===1` 조건 추가
```js
 // IpadSize가 아니거나 회원정보를 눌렀을때만
{(!isIpadSize || isClicked === 1) && <MemberInfo />} 
```
- [x] 내 정보 토글 `z-index:1`추가하여 겹쳐지는 이슈 해결

## 📸 Screenshot

https://github.com/user-attachments/assets/db4bfdfb-66e1-4f97-8a2b-2fbaebdc0aa8



