### PR TITLE
[ TakeTest ] pdf 플러그인 추가된 페이지 구현

### DIFF
--- a/nonsoolmateClient/package.json
+++ b/nonsoolmateClient/package.json
@@ -55,6 +55,7 @@
     "postcss-styled-syntax": "^0.6.3",
     "postcss-syntax": "^0.36.2",
     "prettier": "^3.1.1",
+    "recoil": "^0.7.7",
     "stylelint": "^16.1.0",
     "stylelint-config-recess-order": "^4.4.0",
     "stylelint-config-standard": "^36.0.0",

--- a/nonsoolmateClient/src/App.tsx
+++ b/nonsoolmateClient/src/App.tsx
@@ -5,6 +5,7 @@ import { router } from "router";
 import { RouterProvider } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { useEffect } from "react";
+import { RecoilRoot } from "recoil";
 
 const queryClient = new QueryClient();
 
@@ -18,10 +19,12 @@ function App() {
   });
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <RouterProvider router={router} />
-        <GlobalStyle />
-      </ThemeProvider>
+      <RecoilRoot>
+        <ThemeProvider theme={theme}>
+          <RouterProvider router={router} />
+          <GlobalStyle />
+        </ThemeProvider>
+      </RecoilRoot>
     </QueryClientProvider>
   );
 }

--- a/nonsoolmateClient/src/home/components/TakeTestModal.tsx
+++ b/nonsoolmateClient/src/home/components/TakeTestModal.tsx
@@ -5,6 +5,8 @@ import { media } from "style/responsiveStyle";
 import { DisplayIc, EmptyCircleIc, FilledCircleIc, PrintIc, XIc } from "@assets/index";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
+import { takeTestPdfPlugin } from "recoil/atom";
 
 interface TakeTestModalProps {
   examId: number;
@@ -17,6 +19,8 @@ export default function TakeTestModal(props: TakeTestModalProps) {
   const navigate = useNavigate();
   const [isDisplayClicked, setIsDisplayClicked] = useState<boolean>(false);
   const [isPrintClicked, setIsPrintClicked] = useState<boolean>(false);
+
+  const [, setPdfPlugin] = useRecoilState(takeTestPdfPlugin);
 
   function handleDisplayOption() {
     setIsDisplayClicked((open) => !open);
@@ -36,6 +40,7 @@ export default function TakeTestModal(props: TakeTestModalProps) {
           examId: examId,
         },
       });
+      setPdfPlugin(false);
     }
     // 인쇄,다운로드 클릭 시
     else {
@@ -44,6 +49,7 @@ export default function TakeTestModal(props: TakeTestModalProps) {
           examId: examId,
         },
       });
+      setPdfPlugin(true);
     }
   }
 

--- a/nonsoolmateClient/src/recoil/atom.ts
+++ b/nonsoolmateClient/src/recoil/atom.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const takeTestPdfPlugin = atom<boolean>({
+  key: "takeTestPdfPluginState",
+  default: false,
+});

--- a/nonsoolmateClient/src/takeTest/components/header/TestHeader.tsx
+++ b/nonsoolmateClient/src/takeTest/components/header/TestHeader.tsx
@@ -3,6 +3,9 @@ import styled from "styled-components";
 import Timer from "./Timer";
 import { LeftArrowBlackBtn } from "@assets/index";
 import { media } from "style/responsiveStyle";
+import { useRecoilValue } from "recoil";
+import { takeTestPdfPlugin } from "recoil/atom";
+import { useNavigate } from "react-router-dom";
 
 interface TestHeaderProps {
   changeTestQuitStatus: (testQuitModal: boolean) => void;
@@ -28,34 +31,58 @@ export default function TestHeader(props: TestHeaderProps) {
     examTimeLimit,
   } = props;
 
+  const navigate = useNavigate();
+  const pdfPlugin = useRecoilValue(takeTestPdfPlugin);
+
   function handleBackButton() {
     changeTestQuitStatus(true);
   }
+
   return (
     <TestHeaderContainer>
       <HeaderLeft>
-        <IconBox onClick={handleBackButton} type="button">
-          <LeftArrowBlackBtnIcon />
-        </IconBox>
-        <TestTitle>{openCoachMark || openPrecautionModal ? "시험 예시 화면" : examName}</TestTitle>
+        {pdfPlugin ? (
+          <IconBox onClick={() => navigate("/home/test")} type="button">
+            <LeftArrowBlackBtnIcon />
+          </IconBox>
+        ) : (
+          <IconBox onClick={handleBackButton} type="button">
+            <LeftArrowBlackBtnIcon />
+          </IconBox>
+        )}
+        {pdfPlugin ? (
+          <TestTitle>인쇄/다운로드</TestTitle>
+        ) : (
+          <TestTitle>{openCoachMark || openPrecautionModal ? "시험 예시 화면" : examName}</TestTitle>
+        )}
       </HeaderLeft>
       <IpadHeaderRight>
-        <TimerBox>
-          {openCoachMark || openPrecautionModal ? (
-            <InitTimer>00 : 00 : 00</InitTimer>
-          ) : (
-            <Timer
-              changeTestFinishStatus={changeTestFinishStatus}
-              computeTakeTime={computeTakeTime}
-              openTestFinishModal={openTestFinishModal}
-              openTestSubmitModal={openTestSubmitModal}
-              examTimeLimit={examTimeLimit}
-            />
-          )}
-        </TimerBox>
-        <TestCloseButton type="button" onClick={() => changeTestFinishStatus(true)}>
-          시험 종료
-        </TestCloseButton>
+        {pdfPlugin ? (
+          <></>
+        ) : (
+          <TimerBox>
+            {openCoachMark || openPrecautionModal ? (
+              <InitTimer>00 : 00 : 00</InitTimer>
+            ) : (
+              <Timer
+                changeTestFinishStatus={changeTestFinishStatus}
+                computeTakeTime={computeTakeTime}
+                openTestFinishModal={openTestFinishModal}
+                openTestSubmitModal={openTestSubmitModal}
+                examTimeLimit={examTimeLimit}
+              />
+            )}
+          </TimerBox>
+        )}
+        {pdfPlugin ? (
+          <TestCloseButton onClick={() => navigate("/home/test")} type="button">
+            준비 완료
+          </TestCloseButton>
+        ) : (
+          <TestCloseButton type="button" onClick={() => changeTestFinishStatus(true)}>
+            시험 종료
+          </TestCloseButton>
+        )}
       </IpadHeaderRight>
     </TestHeaderContainer>
   );

--- a/nonsoolmateClient/src/takeTest/components/testPaper/PdfViewer.tsx
+++ b/nonsoolmateClient/src/takeTest/components/testPaper/PdfViewer.tsx
@@ -1,33 +1,49 @@
 import styled from "styled-components";
-import { Plugin, Worker } from "@react-pdf-viewer/core";
+import { Worker } from "@react-pdf-viewer/core";
 import { Viewer } from "@react-pdf-viewer/core";
 import "@react-pdf-viewer/core/lib/styles/index.css";
-import { GetFilePlugin } from "@react-pdf-viewer/get-file";
-import { FullScreenPlugin } from "@react-pdf-viewer/full-screen";
+import { printPlugin, RenderPrintProps } from "@react-pdf-viewer/print";
+import { getFilePlugin, RenderDownloadProps } from "@react-pdf-viewer/get-file";
+import { DownloadCircleIc, PrintCircleIc } from "@assets/index";
+import { useRecoilValue } from "recoil";
+import { takeTestPdfPlugin } from "recoil/atom";
 
 interface PdfViewerProps {
   pdfUrl: string;
-  getFilePluginInstance?: GetFilePlugin;
-  fullScreenPluginInstance?: FullScreenPlugin;
 }
 
 export default function PdfViewer(props: PdfViewerProps) {
-  const { pdfUrl, getFilePluginInstance, fullScreenPluginInstance } = props;
+  const { pdfUrl } = props;
+  const pdfPlugin = useRecoilValue(takeTestPdfPlugin);
 
-  let plugins: Plugin[] | undefined = [];
-  if (getFilePluginInstance && fullScreenPluginInstance) {
-    plugins = [getFilePluginInstance, fullScreenPluginInstance];
-  } else if (getFilePluginInstance) {
-    plugins = [getFilePluginInstance];
-  } else if (fullScreenPluginInstance) {
-    plugins = [fullScreenPluginInstance];
-  }
+  const printPluginInstance = printPlugin();
+  const { Print } = printPluginInstance;
+  const getFilePluginInstance = getFilePlugin();
+  const { Download } = getFilePluginInstance;
 
   return (
     <PdfViewerWrapper>
+      {pdfPlugin && (
+        <PluginContainer>
+          <Print>
+            {(props: RenderPrintProps) => (
+              <PluginButton onClick={props.onClick}>
+                <PrintIcon />
+              </PluginButton>
+            )}
+          </Print>
+          <Download>
+            {(props: RenderDownloadProps) => (
+              <PluginButton onClick={props.onClick}>
+                <DownloadIcon />
+              </PluginButton>
+            )}
+          </Download>
+        </PluginContainer>
+      )}
       <Worker workerUrl="https://unpkg.com/pdfjs-dist@3.4.120/build/pdf.worker.min.js">
         <ViewerWrapper>
-          <Viewer fileUrl={pdfUrl} theme={{ theme: "light" }} plugins={plugins} />
+          <Viewer fileUrl={pdfUrl} theme={{ theme: "light" }} plugins={[printPluginInstance, getFilePluginInstance]} />
         </ViewerWrapper>
       </Worker>
     </PdfViewerWrapper>
@@ -43,4 +59,30 @@ const PdfViewerWrapper = styled.div`
 
 const ViewerWrapper = styled.div`
   height: 100%;
+`;
+
+const PluginContainer = styled.div<{ $selectTest?: boolean; $selectExplanation?: boolean }>`
+  display: flex;
+  gap: 1.2rem;
+  justify-content: center;
+  align-items: center;
+  padding: 1.6rem 0 0.8rem;
+`;
+
+// bottom: ${({ $selectTest, $selectExplanation }) => ($selectTest && $selectExplanation ? "2rem" : "none")};
+const PrintIcon = styled(PrintCircleIc)`
+  width: 3.2rem;
+  height: 3.2rem;
+`;
+
+const DownloadIcon = styled(DownloadCircleIc)`
+  width: 3.2rem;
+  height: 3.2rem;
+`;
+
+const PluginButton = styled.button`
+  margin: 0;
+  padding: 0;
+  border: none;
+  cursor: pointer;
 `;

--- a/nonsoolmateClient/src/takeTest/components/testPaper/TestPaper.tsx
+++ b/nonsoolmateClient/src/takeTest/components/testPaper/TestPaper.tsx
@@ -1,11 +1,11 @@
-import { getFilePlugin } from "@react-pdf-viewer/get-file";
-import { commonFlex } from "style/commonStyle";
 import styled from "styled-components";
 import PdfViewer from "./PdfViewer";
 import testExampleIpad from "@assets/image/blurTestImageIpad.png";
 import testExample from "@assets/image/blurTestImage.png";
 import { useGetUniversityExamPdf } from "takeTest/hooks/useGetUniversityExamPdf";
 import { media } from "style/responsiveStyle";
+import { useRecoilValue } from "recoil";
+import { takeTestPdfPlugin } from "recoil/atom";
 
 interface TestPaperProps {
   openCoachMark: boolean;
@@ -15,7 +15,7 @@ interface TestPaperProps {
 export default function TestPaper(props: TestPaperProps) {
   const { openCoachMark, openPrecautionModal, examId } = props;
 
-  const getFilePluginInstance = getFilePlugin();
+  const pdfPlugin = useRecoilValue(takeTestPdfPlugin);
 
   const response = useGetUniversityExamPdf(examId);
   if (!response) return <></>;
@@ -25,21 +25,26 @@ export default function TestPaper(props: TestPaperProps) {
   } = response;
 
   return (
-    <TestPaperContainer>
-      {openCoachMark || openPrecautionModal ? (
+    <TestPaperContainer $pdfPlugin={pdfPlugin}>
+      {pdfPlugin ? (
+        <PdfViewer pdfUrl={examUrl} />
+      ) : openCoachMark || openPrecautionModal ? (
         <>
           <BlurTestImage src={testExample} />
           <BlurTestImageIpad src={testExampleIpad} />
         </>
       ) : (
-        <PdfViewer pdfUrl={examUrl} getFilePluginInstance={getFilePluginInstance} />
+        <PdfViewer pdfUrl={examUrl} />
       )}
     </TestPaperContainer>
   );
 }
-const TestPaperContainer = styled.section`
-  ${commonFlex}
 
+const TestPaperContainer = styled.section<{ $pdfPlugin: boolean }>`
+  display: flex;
+  flex-direction: ${({ $pdfPlugin }) => ($pdfPlugin ? "column" : "row")};
+  justify-content: center;
+  align-items: center;
   width: 100vw;
   height: calc(100vh - 6.4rem);
 `;

--- a/nonsoolmateClient/src/takeTest/index.tsx
+++ b/nonsoolmateClient/src/takeTest/index.tsx
@@ -11,6 +11,8 @@ import { useLocation } from "react-router-dom";
 import useRefreshPage from "socialLogin/hooks/useRefreshPage";
 import EndTestModal from "./components/modal/EndTestModal";
 import TestPaper from "./components/testPaper/TestPaper";
+import { useRecoilValue } from "recoil";
+import { takeTestPdfPlugin } from "recoil/atom";
 
 export default function index() {
   useRefreshPage();
@@ -22,6 +24,7 @@ export default function index() {
   const [openEndTestModal, setOpenEndTestModal] = useState(false);
   const [totalTime, setTotalTime] = useState(0);
   const [isFile, setIsFile] = useState<File[] | null>(null);
+  const pdfPlugin = useRecoilValue(takeTestPdfPlugin);
 
   const location = useLocation();
   const { examId } = location.state;
@@ -82,8 +85,8 @@ export default function index() {
         />
         <TestPaper examId={examId} openCoachMark={openCoachMark} openPrecautionModal={openPrecautionModal} />
       </TakeTestContainer>
-      {openCoachMark && <CoachMark toPrecautionModal={toPrecautionModal} />}
-      {openPrecautionModal && <PrecautionModal changePrecautionStatus={changePrecautionStatus} />}
+      {!pdfPlugin && openCoachMark && <CoachMark toPrecautionModal={toPrecautionModal} />}
+      {!pdfPlugin && openPrecautionModal && <PrecautionModal changePrecautionStatus={changePrecautionStatus} />}
       {openTestQuitModal && <TestQuitModal changeTestQuitStatus={changeTestQuitStatus} />}
       {openTestFinishModal && (
         <TestFinishModal

--- a/nonsoolmateClient/yarn.lock
+++ b/nonsoolmateClient/yarn.lock
@@ -2364,6 +2364,11 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -3505,6 +3510,13 @@ readable-stream@~2.3.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+recoil@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
+  integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==
+  dependencies:
+    hamt_plus "1.0.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #77 

## 📝 Done Task
- [x] TakeTest : 인쇄, 다운로드 플러그인이 들어간 페이지 UI 

## 🔎 PR Point
- Home에서 시험보기 클릭 후 (`1. 인쇄/다운로드 페이지 2. 시험바로보기 페이지`) 2가지 옵션을 핸들링하기 위해 **url("/takeTest")**은 그대로 하나만 쓰고 **recoil**로 페이지 구분 
> 최대한 기존 컴포넌트를 재사용하고자 했고 `Home`의 컴포넌트와 `TakeTest`의 컴포넌트가 연관되어있는 문제를 해결하기 위해 recoil를 도입했습니다

## 📸 Screenshot
디자인과 플로우는 마무리 되었고 다만 새로고침 시 recoil 상태가 default로 가기에 서버 이슈가 해결되면 세션스토리지 또는 로컬스토리지로 상태를 저장하여 해결해볼게요!

<img width="158" alt="스크린샷 2024-08-21 오후 4 10 38" src="https://github.com/user-attachments/assets/22144a9a-12ea-4e57-8650-0266ec5f93f4">

[
<img width="497" alt="스크린샷 2024-08-21 오후 4 09 51" src="https://github.com/user-attachments/assets/24641e3f-e5c4-4167-b50d-ed741f27959a">
](url)
