### PR TITLE
[ Feat ] 회원 정보 섹션 구현

### DIFF
--- a/nonsoolmateClient/src/components/buttons/Button.tsx
+++ b/nonsoolmateClient/src/components/buttons/Button.tsx
@@ -2,9 +2,10 @@ import { ButtonHTMLAttributes } from "react";
 import styled, { css } from "styled-components";
 
 type Size = "sm" | "md" | "lg" | "xl";
+type Variant = "primary" | "secondary" | "text";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "primary" | "secondary";
+  variant?: Variant;
   size?: Size;
 }
 
@@ -16,7 +17,7 @@ export default function Button({ children, variant = "primary", size = "md", ...
   );
 }
 
-const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Size }>`
+const ButtonWrapper = styled.button<{ variant: Variant; size: Size }>`
   padding: 0.8rem 2.8rem;
 
   border-radius: 8px;
@@ -35,27 +36,25 @@ const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Si
       case "secondary":
         return css`
           border: 1px solid ${({ theme }) => theme.colors.grey_300};
+          border-radius: 4px;
 
-          color: ${({ theme }) => theme.colors.grey_600};
+          color: ${({ theme }) => theme.colors.main_blue};
+          background-color: ${({ theme }) => theme.colors.light_blue};
+        `;
+      case "text":
+        return css`
+          color: ${({ theme }) => theme.colors.main_blue};
           background-color: ${({ theme }) => theme.colors.white};
-
-          &:hover {
-            border: 1px solid ${({ theme }) => theme.colors.grey_600};
-
-            color: ${({ theme }) => theme.colors.main_blue};
-          }
-
-          &:checked {
-            border: 1px solid ${({ theme }) => theme.colors.main_blue};
-
-            color: ${({ theme }) => theme.colors.main_blue};
-          }
         `;
       default:
         return css`
-          background-color: ${({ theme }) => theme.colors.light_blue};
+          color: ${({ theme }) => theme.colors.grey_300};
 
-          border: 1px solid transparent;
+          text-decoration: underline;
+
+          &:hover {
+            color: ${({ theme }) => theme.colors.main_blue};
+          }
         `;
     }
   }}
@@ -68,11 +67,11 @@ const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Si
         `;
       case "md":
         return css`
-          width: 10.6rem;
-        `;
-      case "lg":
-        return css`
           width: 14.4rem;
+        `;
+      case "md":
+        return css`
+          width: 19.9rem;
         `;
       case "xl":
         return css`

--- a/nonsoolmateClient/src/components/buttons/Button.tsx
+++ b/nonsoolmateClient/src/components/buttons/Button.tsx
@@ -1,0 +1,77 @@
+import React, { ButtonHTMLAttributes } from "react";
+import styled, { css } from "styled-components";
+
+type Size = "sm" | "md" | "lg" | "xl";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  variant?: "primary" | "secondary";
+  size?: Size;
+}
+
+export default function Button({ children, variant = "primary", size = "md", ...props }: ButtonProps) {
+  return (
+    <ButtonWrapper type="button" variant={variant} size={size} {...props}>
+      {children}
+    </ButtonWrapper>
+  );
+}
+
+const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Size }>`
+  padding: 0.8rem 2.8rem;
+
+  ${({ variant }) => {
+    switch (variant) {
+      case "primary":
+        return css`
+          background-color: ${({ theme }) => theme.colors.main_blue};
+        `;
+      case "secondary":
+        return css`
+          border: 1px solid ${({ theme }) => theme.colors.grey_300};
+
+          color: ${({ theme }) => theme.colors.grey_600};
+          background-color: ${({ theme }) => theme.colors.white};
+
+          &:hover {
+            border: 1px solid ${({ theme }) => theme.colors.grey_600};
+
+            color: ${({ theme }) => theme.colors.main_blue};
+          }
+        `;
+      default:
+        return css`
+          background-color: ${({ theme }) => theme.colors.light_blue};
+
+          border: 1px solid transparent;
+        `;
+    }
+  }}
+
+  ${({ size }) => {
+    switch (size) {
+      case "sm":
+        return css`
+          width: 8rem;
+        `;
+      case "md":
+        return css`
+          width: 10.6rem;
+        `;
+      case "lg":
+        return css`
+          width: 14.4rem;
+        `;
+      case "xl":
+        return css`
+          width: 40.4rem;
+        `;
+      default:
+        return css`
+          width: 18.4rem;
+        `;
+    }
+  }}
+
+  ${({ theme }) => theme.fonts.Body6};
+`;

--- a/nonsoolmateClient/src/components/buttons/Button.tsx
+++ b/nonsoolmateClient/src/components/buttons/Button.tsx
@@ -1,10 +1,9 @@
-import React, { ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes } from "react";
 import styled, { css } from "styled-components";
 
 type Size = "sm" | "md" | "lg" | "xl";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: React.ReactNode;
   variant?: "primary" | "secondary";
   size?: Size;
 }
@@ -20,10 +19,13 @@ export default function Button({ children, variant = "primary", size = "md", ...
 const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Size }>`
   padding: 0.8rem 2.8rem;
 
+  border-radius: 8px;
+
   ${({ variant }) => {
     switch (variant) {
       case "primary":
         return css`
+          color: ${({ theme }) => theme.colors.white};
           background-color: ${({ theme }) => theme.colors.main_blue};
         `;
       case "secondary":
@@ -35,6 +37,12 @@ const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Si
 
           &:hover {
             border: 1px solid ${({ theme }) => theme.colors.grey_600};
+
+            color: ${({ theme }) => theme.colors.main_blue};
+          }
+
+          &:checked {
+            border: 1px solid ${({ theme }) => theme.colors.main_blue};
 
             color: ${({ theme }) => theme.colors.main_blue};
           }
@@ -74,4 +82,6 @@ const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Si
   }}
 
   ${({ theme }) => theme.fonts.Body6};
+
+  white-space: nowrap;
 `;

--- a/nonsoolmateClient/src/components/buttons/Button.tsx
+++ b/nonsoolmateClient/src/components/buttons/Button.tsx
@@ -21,6 +21,10 @@ const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Si
 
   border-radius: 8px;
 
+  ${({ theme }) => theme.fonts.Body6};
+
+  white-space: nowrap;
+
   ${({ variant }) => {
     switch (variant) {
       case "primary":
@@ -81,7 +85,7 @@ const ButtonWrapper = styled.button<{ variant: "primary" | "secondary"; size: Si
     }
   }}
 
-  ${({ theme }) => theme.fonts.Body6};
-
-  white-space: nowrap;
+  &:disabled {
+    opacity: 0.5;
+  }
 `;

--- a/nonsoolmateClient/src/components/input/Input.tsx
+++ b/nonsoolmateClient/src/components/input/Input.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import styled from "styled-components";
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  placeholder?: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  isError?: boolean;
+  errorMessage?: string;
+}
+
+export default function Input({
+  type,
+  placeholder,
+  value,
+  onChange,
+  isError = false,
+  errorMessage,
+  ...props
+}: InputProps) {
+  return (
+    <>
+      <InputLayout type={type} placeholder={placeholder} value={value} onChange={onChange} {...props} />
+      {isError && <ErrorMessage>{errorMessage}</ErrorMessage>}
+    </>
+  );
+}
+
+const InputLayout = styled.input`
+  position: relative;
+
+  width: 100%;
+
+  padding: 0 1.2rem;
+
+  border: 1px solid ${({ theme }) => theme.colors.grey_100};
+  border-radius: 6px;
+`;
+
+const ErrorMessage = styled.p`
+  position: absolute;
+
+  top: 0.2rem;
+
+  color: ${({ theme }) => theme.colors.error};
+
+  ${({ theme }) => theme.fonts.Body8};
+`;

--- a/nonsoolmateClient/src/components/input/Input.tsx
+++ b/nonsoolmateClient/src/components/input/Input.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   placeholder?: string;
-  value: string;
+  value?: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   isError?: boolean;
   errorMessage?: string;
@@ -39,8 +39,14 @@ const InputLayout = styled.input<{ isError: boolean }>`
 
   outline: none;
 
+  ${({ theme }) => theme.fonts.Body6};
+
   &:focus {
     border: 1px solid ${({ theme }) => theme.colors.main_blue};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.grey_300};
   }
 `;
 

--- a/nonsoolmateClient/src/components/input/Input.tsx
+++ b/nonsoolmateClient/src/components/input/Input.tsx
@@ -20,7 +20,7 @@ export default function Input({
   return (
     <InputWrapper>
       <InputLayout placeholder={placeholder} value={value} onChange={onChange} isError={isError} {...props} />
-      <ErrorMessage isVisible={isError}>{errorMessage}</ErrorMessage>
+      {isError && <ErrorMessage isVisible={isError}>{errorMessage}</ErrorMessage>}
     </InputWrapper>
   );
 }
@@ -28,22 +28,16 @@ export default function Input({
 const InputWrapper = styled.div`
   position: relative;
   display: flex;
-
   flex-direction: column;
-
   gap: 0.2rem;
 `;
 
 const InputLayout = styled.input<{ isError: boolean }>`
   position: relative;
-
   padding: 0 1.2rem;
-
   height: 3.6rem;
-
   border: 1px solid ${({ theme, isError }) => (isError ? theme.colors.error : theme.colors.grey_100)};
   border-radius: 6px;
-
   outline: none;
 
   ${({ theme }) => theme.fonts.Body6};

--- a/nonsoolmateClient/src/components/input/Input.tsx
+++ b/nonsoolmateClient/src/components/input/Input.tsx
@@ -6,10 +6,17 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   value?: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   isError?: boolean;
-  errorMessage?: string;
+  errorMessage?: string | null;
 }
 
-export default function Input({ placeholder, value, onChange, isError = false, errorMessage, ...props }: InputProps) {
+export default function Input({
+  placeholder,
+  value = "",
+  onChange,
+  isError = false,
+  errorMessage,
+  ...props
+}: InputProps) {
   return (
     <InputWrapper>
       <InputLayout placeholder={placeholder} value={value} onChange={onChange} isError={isError} {...props} />

--- a/nonsoolmateClient/src/components/input/Input.tsx
+++ b/nonsoolmateClient/src/components/input/Input.tsx
@@ -9,18 +9,10 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   errorMessage?: string;
 }
 
-export default function Input({
-  type,
-  placeholder,
-  value,
-  onChange,
-  isError = false,
-  errorMessage,
-  ...props
-}: InputProps) {
+export default function Input({ placeholder, value, onChange, isError = false, errorMessage, ...props }: InputProps) {
   return (
     <>
-      <InputLayout type={type} placeholder={placeholder} value={value} onChange={onChange} {...props} />
+      <InputLayout placeholder={placeholder} value={value} onChange={onChange} {...props} />
       {isError && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </>
   );
@@ -35,6 +27,10 @@ const InputLayout = styled.input`
 
   border: 1px solid ${({ theme }) => theme.colors.grey_100};
   border-radius: 6px;
+
+  &:focus {
+    border: 1px solid ${({ theme }) => theme.colors.main_blue};
+  }
 `;
 
 const ErrorMessage = styled.p`

--- a/nonsoolmateClient/src/components/input/Input.tsx
+++ b/nonsoolmateClient/src/components/input/Input.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { InputHTMLAttributes } from "react";
 import styled from "styled-components";
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   placeholder?: string;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -11,34 +11,48 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 
 export default function Input({ placeholder, value, onChange, isError = false, errorMessage, ...props }: InputProps) {
   return (
-    <>
-      <InputLayout placeholder={placeholder} value={value} onChange={onChange} {...props} />
-      {isError && <ErrorMessage>{errorMessage}</ErrorMessage>}
-    </>
+    <InputWrapper>
+      <InputLayout placeholder={placeholder} value={value} onChange={onChange} isError={isError} {...props} />
+      <ErrorMessage isVisible={isError}>{errorMessage}</ErrorMessage>
+    </InputWrapper>
   );
 }
 
-const InputLayout = styled.input`
+const InputWrapper = styled.div`
   position: relative;
+  display: flex;
 
-  width: 100%;
+  flex-direction: column;
+
+  gap: 0.2rem;
+`;
+
+const InputLayout = styled.input<{ isError: boolean }>`
+  position: relative;
 
   padding: 0 1.2rem;
 
-  border: 1px solid ${({ theme }) => theme.colors.grey_100};
+  height: 3.6rem;
+
+  border: 1px solid ${({ theme, isError }) => (isError ? theme.colors.error : theme.colors.grey_100)};
   border-radius: 6px;
+
+  outline: none;
 
   &:focus {
     border: 1px solid ${({ theme }) => theme.colors.main_blue};
   }
 `;
 
-const ErrorMessage = styled.p`
+const ErrorMessage = styled.p<{ isVisible: boolean }>`
   position: absolute;
+  display: ${({ isVisible }) => (isVisible ? "block" : "none")};
 
-  top: 0.2rem;
+  top: 4.2rem;
+  left: 0;
 
   color: ${({ theme }) => theme.colors.error};
-
   ${({ theme }) => theme.fonts.Body8};
+
+  white-space: nowrap;
 `;

--- a/nonsoolmateClient/src/components/radioButton/RadioButton.tsx
+++ b/nonsoolmateClient/src/components/radioButton/RadioButton.tsx
@@ -1,0 +1,54 @@
+import { InputHTMLAttributes } from "react";
+import styled from "styled-components";
+
+export interface RadioButtonProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  name: string;
+}
+
+export default function RadioButton({ label, name, checked, ...props }: RadioButtonProps) {
+  return (
+    <RadioButtonWrapper>
+      <StyledRadioButton type="radio" name={name} checked={checked} {...props} />
+      <Label>{label}</Label>
+    </RadioButtonWrapper>
+  );
+}
+
+export const RadioButtonWrapper = styled.div`
+  display: flex;
+
+  align-items: center;
+
+  gap: 0.8rem;
+`;
+
+const StyledRadioButton = styled.input`
+  display: none;
+
+  & + label {
+    padding: 0.8rem 4.15rem;
+
+    border: 1px solid ${({ theme }) => theme.colors.grey_300};
+    border-radius: 4px;
+
+    color: ${({ theme }) => theme.colors.grey_600};
+
+    transition: 0.2s ease-in-out;
+
+    cursor: pointer;
+  }
+
+  &:checked + label {
+    border: 1px solid transparent;
+
+    color: ${({ theme }) => theme.colors.main_blue};
+    background-color: ${({ theme }) => theme.colors.light_blue};
+  }
+`;
+
+const Label = styled.label`
+  ${({ theme }) => theme.fonts.Body6};
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;

--- a/nonsoolmateClient/src/components/radioButton/RadioButton.tsx
+++ b/nonsoolmateClient/src/components/radioButton/RadioButton.tsx
@@ -1,16 +1,21 @@
 import { InputHTMLAttributes } from "react";
 import styled from "styled-components";
 
-export interface RadioButtonProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface RadioProps {
   label: string;
   name: string;
+  value: string;
 }
 
-export default function RadioButton({ label, name, checked, ...props }: RadioButtonProps) {
+export interface RadioButtonProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
+
+export default function RadioButton({ label, value, id, ...props }: RadioButtonProps) {
   return (
     <RadioButtonWrapper>
-      <StyledRadioButton type="radio" name={name} checked={checked} {...props} />
-      <Label>{label}</Label>
+      <StyledRadioButton id={id} type="radio" value={value} {...props} />
+      <Label htmlFor={id}>{label}</Label>
     </RadioButtonWrapper>
   );
 }
@@ -30,7 +35,6 @@ const StyledRadioButton = styled.input`
     padding: 0.8rem 4.15rem;
 
     border: 1px solid ${({ theme }) => theme.colors.grey_300};
-    border-radius: 4px;
 
     color: ${({ theme }) => theme.colors.grey_600};
 
@@ -49,6 +53,8 @@ const StyledRadioButton = styled.input`
 
 const Label = styled.label`
   ${({ theme }) => theme.fonts.Body6};
+
+  border-radius: 8px;
 
   background-color: ${({ theme }) => theme.colors.white};
 `;

--- a/nonsoolmateClient/src/components/radioButton/RadioButtonGroup.tsx
+++ b/nonsoolmateClient/src/components/radioButton/RadioButtonGroup.tsx
@@ -20,6 +20,7 @@ export default function RadioButtonGroup({ options, onChange, value }: RadioButt
 
       return (
         <RadioButton
+          key={id}
           id={id}
           label={label}
           name={name}

--- a/nonsoolmateClient/src/components/radioButton/RadioButtonGroup.tsx
+++ b/nonsoolmateClient/src/components/radioButton/RadioButtonGroup.tsx
@@ -1,16 +1,35 @@
-import RadioButton, { RadioButtonProps, RadioButtonWrapper } from "@components/radioButton/RadioButton";
+import RadioButton, { RadioButtonProps, RadioButtonWrapper, RadioProps } from "@components/radioButton/RadioButton";
 import { ChangeEvent } from "react";
 
 interface RadioButtonGroupProps {
-  options: RadioButtonProps[];
+  options: RadioProps[];
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  value: string | null;
 }
 
-export default function RadioButtonGroup({ options, onChange }: RadioButtonGroupProps) {
+export default function RadioButtonGroup({ options, onChange, value }: RadioButtonGroupProps) {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const selectedValue = e.target.value;
+
+    onChange({ target: { value: selectedValue } } as ChangeEvent<HTMLInputElement>);
+  };
+
   function renderRadioButton() {
-    return options.map(({ label, value, name }: RadioButtonProps) => {
-      return <RadioButton label={label} name={name} value={value} onChange={onChange} checked={value === value} />;
+    return options.map(({ label, value: optionValue, name }: RadioButtonProps, index) => {
+      const id = `${name}-${index}`;
+
+      return (
+        <RadioButton
+          id={id}
+          label={label}
+          name={name}
+          value={optionValue}
+          onChange={handleChange}
+          checked={value === optionValue}
+        />
+      );
     });
   }
+
   return <RadioButtonWrapper>{renderRadioButton()}</RadioButtonWrapper>;
 }

--- a/nonsoolmateClient/src/components/radioButton/RadioButtonGroup.tsx
+++ b/nonsoolmateClient/src/components/radioButton/RadioButtonGroup.tsx
@@ -1,0 +1,16 @@
+import RadioButton, { RadioButtonProps, RadioButtonWrapper } from "@components/radioButton/RadioButton";
+import { ChangeEvent } from "react";
+
+interface RadioButtonGroupProps {
+  options: RadioButtonProps[];
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function RadioButtonGroup({ options, onChange }: RadioButtonGroupProps) {
+  function renderRadioButton() {
+    return options.map(({ label, value, name }: RadioButtonProps) => {
+      return <RadioButton label={label} name={name} value={value} onChange={onChange} checked={value === value} />;
+    });
+  }
+  return <RadioButtonWrapper>{renderRadioButton()}</RadioButtonWrapper>;
+}

--- a/nonsoolmateClient/src/constants/errorMessage.ts
+++ b/nonsoolmateClient/src/constants/errorMessage.ts
@@ -1,0 +1,9 @@
+export const ERROR_MESSAGE = {
+  LANGUAGE: "* 한글로 입력해주세요.",
+  BIRTHDAY: "* 숫자로 입력해주세요.",
+  EMAIL: "* 올바른 이메일 형식으로 입력해 주세요.",
+  PHONE: "* 010-0000-0000 형식으로 입력해 주세요.",
+  NAME_EMPTY: "* 이름을 입력해주세요.",
+  PHONE_EMPTY: "* 전화번호를 입력해주세요.",
+  EMAIL_EMPTY: "* 이메일을 입력해주세요.",
+};

--- a/nonsoolmateClient/src/pages/mypage/api/getProfile.ts
+++ b/nonsoolmateClient/src/pages/mypage/api/getProfile.ts
@@ -1,13 +1,14 @@
 import { client } from "@api/axios";
 import { Response } from "types/common";
 
-interface DataTypes {
+export interface DataTypes {
   name: string;
   gender: string;
   birthday: string;
   email: string;
   phoneNumber: string;
 }
+
 export async function getProfile() {
   const { data } = await client.get<Response<DataTypes>>("/my/profile");
   return data;

--- a/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
+++ b/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
@@ -1,18 +1,52 @@
 import Button from "@components/buttons/Button";
 import Input from "@components/input/Input";
 import RadioButtonGroup from "@components/radioButton/RadioButtonGroup";
+import Loading from "@pages/loading";
+import { DataTypes } from "@pages/mypage/api/getProfile";
+import useGetProfile from "@pages/mypage/hooks/useGetProfile";
 import useMemberInfo from "@pages/mypage/hooks/useMemberInfo";
-import { ERROR_MESSAGE } from "constants/errorMessage";
+import { AxiosResponse } from "axios";
+import { useState } from "react";
 import { media } from "style/responsiveStyle";
 import styled from "styled-components";
 
 export default function MemberInfo() {
-  const { input, handleChangeInput } = useMemberInfo();
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const { data, isLoading } = useGetProfile();
+
+  const {
+    input,
+    handleChangeInput,
+    isNameError,
+    isEmailError,
+    isPhoneNumberError,
+    isBirthdayError,
+    validateName,
+    validateEmail,
+    validatePhoneNumber,
+    validateBirthday,
+  } = useMemberInfo(data as unknown as AxiosResponse<DataTypes>);
+
+  if (!data || isLoading) {
+    return <Loading />;
+  }
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    // 저장 시 동작하는 로직
+    const isNameValid = !validateName(input.name ?? "");
+    const isEmailValid = !validateEmail(input.email ?? "");
+    const isPhoneNumberValid = !validatePhoneNumber(input.phoneNumber ?? "");
+    const isBirthdayValid = !validateBirthday(input.birthday ?? "");
+
+    const isFormValid = isNameValid && isEmailValid && isPhoneNumberValid && isBirthdayValid;
+
+    setIsSubmitted(true);
+
+    if (!isFormValid) {
+      return;
+    }
   };
 
   return (
@@ -26,8 +60,8 @@ export default function MemberInfo() {
               value={input.name}
               placeholder="이름"
               onChange={(e) => handleChangeInput("name", e)}
-              isError={false}
-              errorMessage={ERROR_MESSAGE.NAME_EMPTY}
+              isError={isSubmitted && isNameError}
+              errorMessage={isSubmitted ? validateName(input.name ?? "") : ""}
               style={{ width: "22.8rem" }}
             />
           </FieldLayout>
@@ -48,11 +82,11 @@ export default function MemberInfo() {
           <FieldLayout>
             <Field>출생연도</Field>
             <Input
-              value={input.birthday || ""}
+              value={input.birthday}
               placeholder="0000"
               onChange={(e) => handleChangeInput("birthday", e)}
-              isError={true}
-              errorMessage={ERROR_MESSAGE.BIRTH}
+              isError={isSubmitted && isBirthdayError}
+              errorMessage={isSubmitted ? validateBirthday(input.birthday ?? "") : ""}
               style={{ width: "6.4rem" }}
             />
             <Field>년</Field>
@@ -60,11 +94,11 @@ export default function MemberInfo() {
           <FieldLayout>
             <Field>전화번호</Field>
             <Input
-              value={input.phoneNumber || ""}
+              value={input.phoneNumber}
               placeholder="000-0000-0000"
               onChange={(e) => handleChangeInput("phoneNumber", e)}
-              isError={false}
-              errorMessage={ERROR_MESSAGE.PHONE}
+              isError={isSubmitted && isPhoneNumberError}
+              errorMessage={isSubmitted ? validatePhoneNumber(input.phoneNumber ?? "") : ""}
               style={{ width: "22.8rem" }}
             />
           </FieldLayout>
@@ -73,16 +107,16 @@ export default function MemberInfo() {
         <Info>
           <Field>이메일</Field>
           <Input
-            value={input.email || ""}
+            value={input.email}
             placeholder="example@email.com"
             onChange={(e) => handleChangeInput("email", e)}
-            isError={false}
-            errorMessage={ERROR_MESSAGE.EMAIL}
+            isError={isSubmitted && isEmailError}
+            errorMessage={isSubmitted ? validateEmail(input.email ?? "") : ""}
             style={{ width: "56.8rem" }}
           />
         </Info>
         <SubmitLayout>
-          <Button variant="primary" size="sm" type="button">
+          <Button variant="primary" size="sm" type="submit">
             저장
           </Button>
         </SubmitLayout>
@@ -93,33 +127,22 @@ export default function MemberInfo() {
 
 const Wrapper = styled.div`
   display: flex;
-
   width: 100%;
-
   flex-direction: column;
-
   background-color: ${({ theme }) => theme.colors.grey_50};
 `;
 
 const MemberInfoContainer = styled.form`
   position: relative;
   display: flex;
-
   flex-direction: column;
-
   gap: 2.8rem;
-
   width: 69.6rem;
-
   padding: 2.4rem;
   margin-left: 2.4rem;
-
   border-radius: 8px;
-
   background-color: ${({ theme }) => theme.colors.white};
-
   box-shadow: 0px 0px 12px 0px rgba(0, 0, 0, 0.08);
-
   ${media.tablet} {
     padding: 3.1rem 3.2rem;
   }
@@ -127,43 +150,32 @@ const MemberInfoContainer = styled.form`
 
 const Info = styled.div`
   display: flex;
-
   align-items: center;
   justify-content: space-between;
-
   gap: 2.4rem;
 `;
 
 const Title = styled.h3`
   display: flex;
-
   padding: 2.4rem;
-
   ${({ theme }) => theme.fonts.Headline5};
-
   white-space: nowrap;
 `;
 
 const Field = styled.h3`
   width: 5.6rem;
-
   ${({ theme }) => theme.fonts.Body3};
-
   white-space: nowrap;
 `;
 
 const FieldLayout = styled.div`
   display: flex;
-
   align-items: center;
-
   gap: 2.4rem;
 `;
 
 const SubmitLayout = styled.div`
   display: flex;
-
   margin-top: 4.8rem;
-
   justify-content: flex-end;
 `;

--- a/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
+++ b/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
@@ -38,7 +38,7 @@ export default function MemberInfo() {
                 { label: "남성", value: "M", name: "gender" },
                 { label: "여성", value: "F", name: "gender" },
               ]}
-              value={input.gender || ""}
+              value={input.gender ?? null}
               onChange={(e) => handleChangeInput("gender", e)}
             />
           </FieldLayout>

--- a/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
+++ b/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
@@ -1,107 +1,170 @@
-import styled from "styled-components";
-
+import Button from "@components/buttons/Button";
+import Input from "@components/input/Input";
+import RadioButtonGroup from "@components/radioButton/RadioButtonGroup";
+import Error from "@pages/error";
+import { ERROR_MESSAGE } from "constants/errorMessage";
+import { useState } from "react";
 import { media } from "style/responsiveStyle";
+import styled from "styled-components";
 import useGetProfile from "../hooks/useGetProfile";
 
 export default function MemberInfo() {
   const response = useGetProfile();
-  if (!response) return <></>;
+  if (!response) return <Error />;
 
   const { name, gender, birthday, email, phoneNumber } = response?.data;
+
+  const initialGender = gender === "M" ? "M" : gender === "F" ? "F" : null;
+  const [checkedGender, setCheckedGender] = useState(initialGender);
+
   return (
-    <MemberInfoContainer>
-      <Info>
-        <Title>이름</Title>
-        <Text>{name}</Text>
-        <GenderBox>
-          <Male $gender={gender}>남성</Male>
-          <Female $gender={gender}>여성</Female>
-        </GenderBox>
-      </Info>
-      <Info>
-        <Title>출생연도</Title>
-        <Text>{birthday}년</Text>
-      </Info>
-      <Info>
-        <Title>이메일</Title>
-        <Text>{email}</Text>
-        <ReviseButton>수정하기</ReviseButton>
-      </Info>
-      <Info>
-        <Title>전화번호</Title>
-        <Text>{phoneNumber}</Text>
-        <ReviseButton>수정하기</ReviseButton>
-      </Info>
-    </MemberInfoContainer>
+    <Wrapper>
+      <Title>회원정보</Title>
+      <MemberInfoContainer>
+        <Info>
+          <FieldLayout>
+            <Field>이름</Field>
+            <Input
+              value={name}
+              placeholder="이름"
+              onChange={() => {}}
+              isError={false}
+              errorMessage={ERROR_MESSAGE.NAME_EMPTY}
+              style={{ width: "22.8rem" }}
+            />
+          </FieldLayout>
+          <FieldLayout>
+            <Field>성별</Field>
+            <RadioButtonGroup
+              options={[
+                { label: "남성", value: "M", name: "gender" },
+                { label: "여성", value: "F", name: "gender" },
+              ]}
+              onChange={(e) => {
+                setCheckedGender(e.target.value);
+              }}
+            />
+          </FieldLayout>
+        </Info>
+
+        <Info>
+          <FieldLayout>
+            <Field>출생연도</Field>
+            <Input
+              value={birthday}
+              placeholder="0000"
+              onChange={() => {}}
+              isError={true}
+              errorMessage={ERROR_MESSAGE.BIRTH}
+              style={{ width: "6.4rem" }}
+            />
+            <Field>년</Field>
+          </FieldLayout>
+          <FieldLayout>
+            <Field>전화번호</Field>
+            <Input
+              value={phoneNumber}
+              placeholder="000-0000-0000"
+              onChange={() => {}}
+              isError={false}
+              errorMessage={ERROR_MESSAGE.PHONE}
+              style={{ width: "22.8rem" }}
+            />
+          </FieldLayout>
+        </Info>
+
+        <Info>
+          <Field>이메일</Field>
+          <Input
+            value={email}
+            placeholder="example@email.com"
+            onChange={() => {}}
+            isError={false}
+            errorMessage={ERROR_MESSAGE.EMAIL}
+            style={{ width: "56.8rem" }}
+          />
+        </Info>
+        <SubmitLayout>
+          <Button variant="primary" size="sm" type="submit">
+            저장
+          </Button>
+        </SubmitLayout>
+      </MemberInfoContainer>
+    </Wrapper>
   );
 }
 
-const MemberInfoContainer = styled.ul`
+const Wrapper = styled.div`
   display: flex;
-  flex-direction: column;
-  gap: 2.8rem;
-  position: relative;
+
   width: 100%;
-  padding: 8rem 0 8rem 6.4rem;
+
+  flex-direction: column;
+
+  background-color: ${({ theme }) => theme.colors.grey_50};
+`;
+
+const MemberInfoContainer = styled.ul`
+  position: relative;
+  display: flex;
+
+  flex-direction: column;
+
+  gap: 2.8rem;
+
+  width: 69.6rem;
+
+  padding: 2.4rem;
+  margin-left: 2.4rem;
+
+  border-radius: 8px;
+
+  background-color: ${({ theme }) => theme.colors.white};
 
   ${media.tablet} {
     padding: 3.1rem 3.2rem;
   }
 `;
 
-const Info = styled.li`
+const Info = styled.div`
   display: flex;
-  gap: 0.2rem;
+
+  align-items: center;
+  justify-content: space-between;
+
+  gap: 2.4rem;
 `;
 
-const Title = styled.p`
+const Title = styled.h3`
+  display: flex;
+
+  padding: 2.4rem;
+
+  ${({ theme }) => theme.fonts.Headline5};
+
+  white-space: nowrap;
+`;
+
+const Field = styled.h3`
+  width: 5.6rem;
+
   ${({ theme }) => theme.fonts.Body3};
 
-  width: 8.8rem;
+  white-space: nowrap;
 `;
 
-const Text = styled.p`
-  ${({ theme }) => theme.fonts.Body4};
-`;
-
-const ReviseButton = styled.button`
-  ${({ theme }) => theme.fonts.Body4};
-
-  position: absolute;
-  right: 22.5rem;
-  width: 7.6rem;
-  color: ${({ theme }) => theme.colors.main_blue};
-
-  ${media.tablet} {
-    right: 3.2rem;
-  }
-`;
-
-const GenderBox = styled.ul`
-  ${({ theme }) => theme.fonts.Body7};
-
+const FieldLayout = styled.div`
   display: flex;
-  gap: 0.6rem;
-  position: absolute;
-  right: 50rem;
 
-  ${media.tablet} {
-    right: 3.2rem;
-  }
+  align-items: center;
+
+  gap: 2.4rem;
 `;
 
-const Male = styled.li<{ $gender: String }>`
-  padding: 0.4rem 0.8rem;
-  border: 1px solid ${({ $gender, theme }) => ($gender == "M" ? theme.colors.main_blue : theme.colors.grey_400)};
-  border-radius: 4px;
-  background-color: ${({ $gender, theme }) => ($gender == "M" ? theme.colors.light_blue : theme.colors.grey_50)};
-  color: ${({ $gender, theme }) => ($gender == "M" ? theme.colors.main_blue : theme.colors.grey_400)};
-`;
+const SubmitLayout = styled.div`
+  display: flex;
 
-const Female = styled.li<{ $gender: String }>`
-  padding: 0.4rem 0.8rem;
-  border: 1px solid ${({ $gender, theme }) => ($gender == "F" ? theme.colors.main_blue : theme.colors.grey_400)};
-  border-radius: 4px;
-  background-color: ${({ $gender, theme }) => ($gender == "F" ? theme.colors.light_blue : theme.colors.grey_50)};
-  color: ${({ $gender, theme }) => ($gender == "F" ? theme.colors.main_blue : theme.colors.grey_400)};
+  margin-top: 4.8rem;
+
+  justify-content: flex-end;
 `;

--- a/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
+++ b/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
@@ -1,33 +1,31 @@
 import Button from "@components/buttons/Button";
 import Input from "@components/input/Input";
 import RadioButtonGroup from "@components/radioButton/RadioButtonGroup";
-import Error from "@pages/error";
+import useMemberInfo from "@pages/mypage/hooks/useMemberInfo";
 import { ERROR_MESSAGE } from "constants/errorMessage";
-import { useState } from "react";
 import { media } from "style/responsiveStyle";
 import styled from "styled-components";
-import useGetProfile from "../hooks/useGetProfile";
 
 export default function MemberInfo() {
-  const response = useGetProfile();
-  if (!response) return <Error />;
+  const { input, handleChangeInput } = useMemberInfo();
 
-  const { name, gender, birthday, email, phoneNumber } = response?.data;
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
 
-  const initialGender = gender === "M" ? "M" : gender === "F" ? "F" : null;
-  const [checkedGender, setCheckedGender] = useState(initialGender);
+    // 저장 시 동작하는 로직
+  };
 
   return (
     <Wrapper>
       <Title>회원정보</Title>
-      <MemberInfoContainer>
+      <MemberInfoContainer onSubmit={handleSubmit}>
         <Info>
           <FieldLayout>
             <Field>이름</Field>
             <Input
-              value={name}
+              value={input.name}
               placeholder="이름"
-              onChange={() => {}}
+              onChange={(e) => handleChangeInput("name", e)}
               isError={false}
               errorMessage={ERROR_MESSAGE.NAME_EMPTY}
               style={{ width: "22.8rem" }}
@@ -40,9 +38,8 @@ export default function MemberInfo() {
                 { label: "남성", value: "M", name: "gender" },
                 { label: "여성", value: "F", name: "gender" },
               ]}
-              onChange={(e) => {
-                setCheckedGender(e.target.value);
-              }}
+              value={input.gender || ""}
+              onChange={(e) => handleChangeInput("gender", e)}
             />
           </FieldLayout>
         </Info>
@@ -51,9 +48,9 @@ export default function MemberInfo() {
           <FieldLayout>
             <Field>출생연도</Field>
             <Input
-              value={birthday}
+              value={input.birthday || ""}
               placeholder="0000"
-              onChange={() => {}}
+              onChange={(e) => handleChangeInput("birthday", e)}
               isError={true}
               errorMessage={ERROR_MESSAGE.BIRTH}
               style={{ width: "6.4rem" }}
@@ -63,9 +60,9 @@ export default function MemberInfo() {
           <FieldLayout>
             <Field>전화번호</Field>
             <Input
-              value={phoneNumber}
+              value={input.phoneNumber || ""}
               placeholder="000-0000-0000"
-              onChange={() => {}}
+              onChange={(e) => handleChangeInput("phoneNumber", e)}
               isError={false}
               errorMessage={ERROR_MESSAGE.PHONE}
               style={{ width: "22.8rem" }}
@@ -76,16 +73,16 @@ export default function MemberInfo() {
         <Info>
           <Field>이메일</Field>
           <Input
-            value={email}
+            value={input.email || ""}
             placeholder="example@email.com"
-            onChange={() => {}}
+            onChange={(e) => handleChangeInput("email", e)}
             isError={false}
             errorMessage={ERROR_MESSAGE.EMAIL}
             style={{ width: "56.8rem" }}
           />
         </Info>
         <SubmitLayout>
-          <Button variant="primary" size="sm" type="submit">
+          <Button variant="primary" size="sm" type="button">
             저장
           </Button>
         </SubmitLayout>
@@ -104,7 +101,7 @@ const Wrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.grey_50};
 `;
 
-const MemberInfoContainer = styled.ul`
+const MemberInfoContainer = styled.form`
   position: relative;
   display: flex;
 
@@ -120,6 +117,8 @@ const MemberInfoContainer = styled.ul`
   border-radius: 8px;
 
   background-color: ${({ theme }) => theme.colors.white};
+
+  box-shadow: 0px 0px 12px 0px rgba(0, 0, 0, 0.08);
 
   ${media.tablet} {
     padding: 3.1rem 3.2rem;

--- a/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
+++ b/nonsoolmateClient/src/pages/mypage/components/MemberInfo.tsx
@@ -17,7 +17,9 @@ export default function MemberInfo() {
 
   const {
     input,
+    gender,
     handleChangeInput,
+    handleChangeGender,
     isNameError,
     isEmailError,
     isPhoneNumberError,
@@ -72,8 +74,8 @@ export default function MemberInfo() {
                 { label: "남성", value: "M", name: "gender" },
                 { label: "여성", value: "F", name: "gender" },
               ]}
-              value={input.gender ?? null}
-              onChange={(e) => handleChangeInput("gender", e)}
+              value={gender ?? null}
+              onChange={(e) => handleChangeGender(e.target.value)}
             />
           </FieldLayout>
         </Info>

--- a/nonsoolmateClient/src/pages/mypage/components/SideNav.tsx
+++ b/nonsoolmateClient/src/pages/mypage/components/SideNav.tsx
@@ -53,12 +53,11 @@ const Ul = styled.ul`
   width: 43.1rem;
   height: 100%;
 
-  flex-shrink: 0;
   flex-direction: column;
 
   justify-content: flex-start;
 
-  gap: 2rem;
+  gap: 0.4rem;
 
   padding: 2.4rem 2.4rem 0 21.5rem;
 
@@ -70,6 +69,8 @@ const Ul = styled.ul`
 `;
 
 const NavHeader = styled.header`
+  margin-bottom: 2rem;
+
   ${({ theme }) => theme.fonts.Headline4};
 `;
 

--- a/nonsoolmateClient/src/pages/mypage/components/TabletSideNav.tsx
+++ b/nonsoolmateClient/src/pages/mypage/components/TabletSideNav.tsx
@@ -37,8 +37,7 @@ const Nav = styled.nav`
 `;
 
 const Header = styled.h2`
-  margin-top: 3.2rem;
-  margin-bottom: 2.4rem;
+  margin: 3.2rem 0 2.4rem 0;
 
   color: ${({ theme }) => theme.colors.black};
   ${({ theme }) => theme.fonts.Headline5};

--- a/nonsoolmateClient/src/pages/mypage/hooks/useGetProfile.ts
+++ b/nonsoolmateClient/src/pages/mypage/hooks/useGetProfile.ts
@@ -5,9 +5,8 @@ const QUERY_KEY = {
   getProfile: "getProfile",
 };
 export default function useGetProfile() {
-  const { data } = useQuery({
+  return useQuery({
     queryKey: [QUERY_KEY.getProfile],
     queryFn: () => getProfile(),
   });
-  return data;
 }

--- a/nonsoolmateClient/src/pages/mypage/hooks/useMemberInfo.ts
+++ b/nonsoolmateClient/src/pages/mypage/hooks/useMemberInfo.ts
@@ -1,7 +1,7 @@
 import { DataTypes } from "@pages/mypage/api/getProfile";
 import { AxiosResponse } from "axios";
 import { ERROR_MESSAGE } from "constants/errorMessage";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 type Input = "name" | "gender" | "email" | "birthday" | "phoneNumber";
 
@@ -13,6 +13,17 @@ export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
     email: response?.data?.email,
     phoneNumber: response?.data?.phoneNumber,
   });
+
+  useEffect(() => {
+    // response값을 받아올 때 다시 상태 업데이트
+    setInput({
+      name: response?.data?.name,
+      gender: response?.data?.gender,
+      birthday: response?.data?.birthday,
+      email: response?.data?.email,
+      phoneNumber: response?.data?.phoneNumber,
+    });
+  }, [response]);
 
   const handleChangeInput = useCallback((key: Input, e: React.ChangeEvent<HTMLInputElement>) => {
     let value = e.target.value;

--- a/nonsoolmateClient/src/pages/mypage/hooks/useMemberInfo.ts
+++ b/nonsoolmateClient/src/pages/mypage/hooks/useMemberInfo.ts
@@ -6,9 +6,9 @@ import { useCallback, useEffect, useState } from "react";
 type Input = "name" | "gender" | "email" | "birthday" | "phoneNumber";
 
 export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
+  const [gender, setGender] = useState<string | null>(null);
   const [input, setInput] = useState({
     name: response?.data?.name,
-    gender: response?.data?.gender,
     birthday: response?.data?.birthday,
     email: response?.data?.email,
     phoneNumber: response?.data?.phoneNumber,
@@ -18,11 +18,12 @@ export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
     // response값을 받아올 때 다시 상태 업데이트
     setInput({
       name: response?.data?.name,
-      gender: response?.data?.gender,
       birthday: response?.data?.birthday,
       email: response?.data?.email,
       phoneNumber: response?.data?.phoneNumber,
     });
+
+    setGender(response?.data?.gender);
   }, [response]);
 
   const handleChangeInput = useCallback((key: Input, e: React.ChangeEvent<HTMLInputElement>) => {
@@ -36,6 +37,10 @@ export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
       ...prev,
       [key]: value,
     }));
+  }, []);
+
+  const handleChangeGender = useCallback((value: string | null) => {
+    setGender(value);
   }, []);
 
   const validateName = useCallback((value: string) => {
@@ -75,7 +80,9 @@ export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
 
   return {
     input,
+    gender,
     handleChangeInput,
+    handleChangeGender,
     validateName,
     validatePhoneNumber,
     validateEmail,

--- a/nonsoolmateClient/src/pages/mypage/hooks/useMemberInfo.ts
+++ b/nonsoolmateClient/src/pages/mypage/hooks/useMemberInfo.ts
@@ -1,0 +1,32 @@
+import useGetProfile from "@pages/mypage/hooks/useGetProfile";
+import { useCallback, useState } from "react";
+
+type Input = "name" | "gender" | "email" | "birthday" | "phoneNumber";
+
+export default function useMemberInfo() {
+  const response = useGetProfile();
+
+  if (!response) console.error();
+
+  const [input, setInput] = useState({
+    name: response?.data?.name,
+    gender: response?.data?.gender,
+    birthday: response?.data?.birthday,
+    email: response?.data?.email,
+    phoneNumber: response?.data?.phoneNumber,
+  });
+
+  const handleChangeInput = useCallback((key: Input, e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+
+    setInput((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  }, []);
+
+  return {
+    input,
+    handleChangeInput,
+  };
+}

--- a/nonsoolmateClient/src/pages/mypage/hooks/useMemberInfo.ts
+++ b/nonsoolmateClient/src/pages/mypage/hooks/useMemberInfo.ts
@@ -1,13 +1,11 @@
-import useGetProfile from "@pages/mypage/hooks/useGetProfile";
+import { DataTypes } from "@pages/mypage/api/getProfile";
+import { AxiosResponse } from "axios";
+import { ERROR_MESSAGE } from "constants/errorMessage";
 import { useCallback, useState } from "react";
 
 type Input = "name" | "gender" | "email" | "birthday" | "phoneNumber";
 
-export default function useMemberInfo() {
-  const response = useGetProfile();
-
-  if (!response) console.error();
-
+export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
   const [input, setInput] = useState({
     name: response?.data?.name,
     gender: response?.data?.gender,
@@ -17,7 +15,11 @@ export default function useMemberInfo() {
   });
 
   const handleChangeInput = useCallback((key: Input, e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
+    let value = e.target.value;
+
+    if (key === "phoneNumber") {
+      value = value.replace(/[^\d]/g, "").replace(/(\d{3})(\d{3,4})(\d{4})/, "$1-$2-$3");
+    }
 
     setInput((prev) => ({
       ...prev,
@@ -25,8 +27,51 @@ export default function useMemberInfo() {
     }));
   }, []);
 
+  const validateName = useCallback((value: string) => {
+    if (value.length == 0) {
+      return ERROR_MESSAGE.NAME_EMPTY;
+    }
+  }, []);
+
+  const validateEmail = useCallback((value: string) => {
+    if (value.length == 0) {
+      return ERROR_MESSAGE.EMAIL_EMPTY;
+    }
+    if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value)) {
+      return ERROR_MESSAGE.EMAIL;
+    }
+  }, []);
+
+  const validatePhoneNumber = useCallback((value: string) => {
+    if (!/^\d{3}-\d{3,4}-\d{4}$/.test(value)) {
+      return ERROR_MESSAGE.PHONE;
+    }
+    if (value.length == 0) {
+      return ERROR_MESSAGE.PHONE_EMPTY;
+    }
+  }, []);
+
+  const validateBirthday = useCallback((value: string) => {
+    if (isNaN(Number(value))) {
+      return ERROR_MESSAGE.BIRTHDAY;
+    }
+  }, []);
+
+  const isNameError = !!validateName(input.name ?? "");
+  const isEmailError = !!validateEmail(input.email ?? "");
+  const isPhoneNumberError = !!validatePhoneNumber(input.phoneNumber ?? "");
+  const isBirthdayError = !!validateBirthday(input.birthday ?? "");
+
   return {
     input,
     handleChangeInput,
+    validateName,
+    validatePhoneNumber,
+    validateEmail,
+    validateBirthday,
+    isNameError,
+    isEmailError,
+    isPhoneNumberError,
+    isBirthdayError,
   };
 }

--- a/nonsoolmateClient/src/pages/mypage/types/Info.ts
+++ b/nonsoolmateClient/src/pages/mypage/types/Info.ts
@@ -1,0 +1,7 @@
+export type Info = {
+  name: string;
+  gender: string | null;
+  birthday: string;
+  email: string;
+  phoneNumber: string;
+};


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #97 

## 📝 Done Task
- [x] 회원 정보 섹션 구현

## 🔎 PR Point
<!-- 리뷰어에게 내 코드를 설명해주세요. -->
### 🐣 Input 공통 컴포넌트
input이 많이 쓰이는 뷰여서 Input 공통 컴포넌트를 만들어 보았습니다.
이미 개발된 뷰에 적용하긴 리소스가 좀 필요할 것 같아서 추후 리팩 기간 때 기존 Input 컴포넌트 개별로 구현된 것들 공통 컴포넌트로 통일되게 사용하면 좀 더 코드의 가독성과 유지 보수 측면에서 좋아질 것 같습니다  !
```tsx
    <InputWrapper>
      <InputLayout placeholder={placeholder} value={value} onChange={onChange} isError={isError} {...props} />
      {isError && <ErrorMessage isVisible={isError}>{errorMessage}</ErrorMessage>}
    </InputWrapper>
```
모든 Input에서 조건에 맞지 않을 경우 에러 메시지를 띄워주길래 옵셔널로 error여부도 받아서 에러 메시지를 Input 아래에 띄워주는 식으로 input 컴포넌트를 구성했습니다.

<br />

### 🐣 RadioButton 공통 컴포넌트
사실 라디오 버튼을 구현하기 전 Button 컴포넌트를 먼저 만들었는데, 구현하다보니 아래처럼 둘 중에 하나의 값만 가져야 하는 라디오 버튼인 걸 깨달아버려서,, ! 라디오 버튼도 공통 컴포넌트로 만들어봤어요. 
지금은  또 다른 곳에 재사용 되는지 모르겠지만 .,,, 라디오 버튼이 더 생겨서 재사용 할 수 있길 바래봅니다 ...

<img width="487" alt="스크린샷 2024-10-03 오후 11 51 25" src="https://github.com/user-attachments/assets/db27840f-ca1e-4a66-81e4-b526cc0575b8">

해당 공통 컴포넌트는 RadioButton.tsx와 RadioButtonGrouup.tsx로 이뤄져있고, 사용할 땐 아래 코드와 같이 버튼들에 해당하는 options를 정의해주면 됩니다 ! 
(이때 name을 같은 값으로 주어야 라디오 버튼들 중 하나만 선택될 수 있게 할 수 있습니다.)
```tsx
            <RadioButtonGroup
              options={[
                { label: "남성", value: "M", name: "gender" },
                { label: "여성", value: "F", name: "gender" },
              ]}
              value={input.gender ?? null}
              onChange={(e) => handleChangeInput("gender", e)}
            />
```

<br />

### 🐣 Button 공통 컴포넌트
Button의 경우 3가지의 variant를 고려해서 제작했습니다. 
1. primary
<img width="116" alt="스크린샷 2024-10-03 오후 11 57 56" src="https://github.com/user-attachments/assets/b95d7ba9-3425-4cfa-b1b4-764bc63c2f8d">

2. secondary

<img width="242" alt="스크린샷 2024-10-03 오후 11 58 43" src="https://github.com/user-attachments/assets/506be0aa-4ec3-4293-88

3. text (앞 상태가 호버라고 판단했습니다.)

<img width="110" alt="스크린샷 2024-10-04 오전 12 01 08" src="https://github.com/user-attachments/assets/5423ad17-9df5-4fff-b3ed-35c181cec092">

<img width="116" alt="스크린샷 2024-10-04 오전 12 01 23" src="https://github.com/user-attachments/assets/1b325501-6705-4534-9efc-6fa7b79506ce">

예를 들어 1번의 저장 버튼은 다음과 같이 사용해줄 수 있습니다.
```tsx
          <Button variant="primary" size="sm" type="submit">
            저장
          </Button>
```


또한 Size도 정의해주었는데, 이는 더 다양하게 나올 경우 Size의 타입을 정의해주기보다 외부에서 주입해주는 게 낫다고 판단했습니다. 
어찌저찌 3개의 공통 컴포넌트를 만들게 됐는데 많은 피드백 부탁드립니다 ..!


## 💣 Trouble Shooting
모든 필드들에서 에러가 발생하지 않는 경우 저장 버튼이 동작하고, 아닌 경우 저장 버튼을 누를 때 에러가 보이도록 하는 과정에서 시간을 좀 썼던 것 같습니다.
```tsx
    const isNameValid = !validateName(input.name ?? "");
    const isEmailValid = !validateEmail(input.email ?? "");
    const isPhoneNumberValid = !validatePhoneNumber(input.phoneNumber ?? "");
    const isBirthdayValid = !validateBirthday(input.birthday ?? "");

    const isFormValid = isNameValid && isEmailValid && isPhoneNumberValid && isBirthdayValid;

    setIsSubmitted(true);

    if (!isFormValid) {
      return;
    }
```
위 코드와 같이 에러가 발생할 경우 그에 맞는 에러 메시지를 반환하는 `validateName`, `validateEmail`, `validatePhoneNumber`, `validateBirthday`가 `false`를 반환, 즉 에러가 발생하지 않는 경우에 `isFormValid`라는 변수에 true가 저장되게 했습니다. 
그 다음 isFormValid가 false를 반환하게 되는 경우 바로 return해서 저장 버튼이 실행되지 않도록 해주었습니다.

에러 메시지의 경우 isSubmitted를 통해 해당 값이 true인 경우에 에러 메시지를 띄워주도록 코드를 작성해주어 해결했습니다.

## 📸 Screenshot


https://github.com/user-attachments/assets/99eb50cc-7061-4297-b6e0-c564cdd56096

