### PR TITLE
[ HotFix ] 사용자 이탈 방지 위한 왈라폼 링크 연결

### DIFF
--- a/nonsoolmateClient/src/components/onbordingheader/HeaderRight.tsx
+++ b/nonsoolmateClient/src/components/onbordingheader/HeaderRight.tsx
@@ -1,4 +1,4 @@
-import LoginButton from "@components/buttons/LoginButton";
+// import LoginButton from "@components/buttons/LoginButton";
 import { commonFlex } from "style/commonStyle";
 import { media } from "style/responsiveStyle";
 import styled from "styled-components";

--- a/nonsoolmateClient/src/components/onbordingheader/HeaderRight.tsx
+++ b/nonsoolmateClient/src/components/onbordingheader/HeaderRight.tsx
@@ -20,7 +20,7 @@ export default function HeaderRight(props: HeaderRightProps) {
     return (
       <Container>
         <MembershipButton />
-        <LoginButton />
+        {/* <LoginButton /> */}
       </Container>
     );
 

--- a/nonsoolmateClient/src/pages/membership/components/subscribe/PurchaseButton.tsx
+++ b/nonsoolmateClient/src/pages/membership/components/subscribe/PurchaseButton.tsx
@@ -1,13 +1,14 @@
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
 import { commonFlex } from "style/commonStyle";
 import styled from "styled-components";
 
 export default function PurchaseButton() {
-  const navigate = useNavigate();
-  function clickPurchaseButton() {
-    navigate("/payment");
-  }
-  return <Button onClick={clickPurchaseButton}>구매하기</Button>;
+  // const navigate = useNavigate();
+  const wallaUrl = "https://walla.my/v/5VQBBMKXWe05gbyn2xn5";
+  // function clickPurchaseButton() {
+  //   navigate("/payment");
+  // }
+  return <Button onClick={() => window.open(wallaUrl)}>구매하기</Button>;
 }
 
 const Button = styled.button`


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #107 

## 📝 Done Task
- [x] 로그인 버튼 숨기기
- [x] 멤버십 시작하기 버튼에 왈라폼 링크 연결

## 🔎 PR Point
<!-- 리뷰어에게 내 코드를 설명해주세요. -->
이렇게 막아놓으면 서버는 운영 서버에 지금 배포하지 않아도 된다고 해서 해당 PR 머지 후 바로 main에 머지하겠습니다!
## 📸 Screenshot
ㅋㅋ..로그인 버튼 없앴읍니다,,
<img width="1498" alt="스크린샷 2024-10-08 오전 12 02 13" src="https://github.com/user-attachments/assets/0083afdb-6bbf-4f22-89cd-ce9f6b6742f4">

멤버십에서 구매하기 누르면 아래 왈라폼으로 연결됩니다!
<img width="1498" alt="스크린샷 2024-10-08 오전 12 02 33" src="https://github.com/user-attachments/assets/0514cc3d-48a9-4ed2-83cc-871dcd5212ff">

