### PR TITLE
[ Feat ] 마이페이지 카드 변경

### DIFF
--- a/nonsoolmateClient/src/pages/mypage/components/PaymentInfo.tsx
+++ b/nonsoolmateClient/src/pages/mypage/components/PaymentInfo.tsx
@@ -1,11 +1,13 @@
 import { DiscountIc, SmallCouponIc } from "@assets/index";
 import Button from "@components/buttons/Button";
+import useGetCustomerInfo from "@pages/payment/hooks/useGetCustomerInfo";
 import useGetPayment from "@pages/mypage/hooks/useGetPayment";
 import { formatDate } from "@pages/mypage/utils/date";
 import CouponModal from "@pages/payment/components/coupon/CouponModal";
 import { COUPON_NOT_REGISTER } from "constants/coupon";
 import { useState } from "react";
 import styled from "styled-components";
+import { registerCard } from "@utils/registerCard";
 
 export default function PaymentInfo() {
   const { data } = useGetPayment();
@@ -36,6 +38,23 @@ export default function PaymentInfo() {
     changeNextMonthCouponModalStatus(true);
   }
 
+  const from = location.pathname;
+  sessionStorage.setItem("from", from);
+  const clientKey = `${import.meta.env.VITE_CLIENTKEY}`;
+  const customerResponse = useGetCustomerInfo();
+  if (!customerResponse) {
+    return <></>;
+  }
+  const customerKey = customerResponse.customerKey;
+
+  function registerCardHandler() {
+    const from = sessionStorage.getItem("from");
+    registerCard({
+      clientKey,
+      customerKey,
+      from: from || "",
+    });
+  }
   return (
     <PaymentInfoWrapper>
       <Title>다음 결제 정보</Title>
@@ -50,7 +69,9 @@ export default function PaymentInfo() {
             <InfoTitle>결제 수단</InfoTitle>
             <Info>{data?.paymentMethod}</Info>
           </Payment>
-          <Button variant="text">결제 수단 변경하기</Button>
+          <Button variant="text" onClick={registerCardHandler}>
+            결제 수단 변경하기
+          </Button>
         </PaymentInfoBox>
 
         <PaymentInfoBox>

--- a/nonsoolmateClient/src/pages/payment/components/Success.tsx
+++ b/nonsoolmateClient/src/pages/payment/components/Success.tsx
@@ -12,8 +12,9 @@ export default function Success() {
   const customerKey = searchParams.get("customerKey");
   const authKey = searchParams.get("authKey");
   const id = searchParams.get("id");
-  const { mutate: updateCard } = usePutCardUpdate(navigate, id);
-  const { mutate: postMutate } = usePostCardRegister(navigate, id);
+  const from = searchParams.get("from");
+  const { mutate: updateCard } = usePutCardUpdate(navigate, id, from);
+  const { mutate: postMutate } = usePostCardRegister(navigate, id, from);
   const { cardInfo, isLoading } = useGetCardInfo();
 
   useEffect(() => {
@@ -25,7 +26,7 @@ export default function Success() {
     } else {
       postMutate({ authKey: authKey });
     }
-  }, [authKey, cardInfo, navigate, postMutate, id]);
+  }, [authKey, cardInfo, navigate, postMutate, id, from]);
 
   if (!authKey) {
     return <></>;

--- a/nonsoolmateClient/src/pages/payment/components/register/RegisterLayout.tsx
+++ b/nonsoolmateClient/src/pages/payment/components/register/RegisterLayout.tsx
@@ -11,7 +11,7 @@ import { COUPON_NOT_REGISTER } from "constants/coupon";
 
 interface RegisterLayoutProps {
   changeCouponModalStatus: (open: boolean) => void;
-  registerCard: () => void;
+  registerCardHandler: () => void;
   handleCouponTxtStatus: (coupon: string, dcInfo: string) => void;
   isCouponOpen: boolean;
   couponTxt: string;
@@ -30,7 +30,7 @@ export default function RegisterLayout(props: RegisterLayoutProps) {
     couponTxt,
     dcInfo,
     handleCouponTxtStatus,
-    registerCard,
+    registerCardHandler,
     activeCouponId,
     handleActiveCouponId,
     notRegisterError,
@@ -55,7 +55,7 @@ export default function RegisterLayout(props: RegisterLayoutProps) {
             </Title>
             <RegisterButton
               button={item.buttonText}
-              onClick={item.buttonText === "쿠폰 사용" ? openCouponModal : registerCard}
+              onClick={item.buttonText === "쿠폰 사용" ? openCouponModal : registerCardHandler}
             />
           </TitleContainer>
           <Content $payError={notRegisterError && item.title === "결제 수단"}>

--- a/nonsoolmateClient/src/pages/payment/hooks/usePostCardRegister.ts
+++ b/nonsoolmateClient/src/pages/payment/hooks/usePostCardRegister.ts
@@ -2,12 +2,16 @@ import { useMutation } from "@tanstack/react-query";
 import { postCardRegister } from "../api/postCardRegister";
 import { NavigateFunction } from "react-router-dom";
 
-export function usePostCardRegister(navigate: NavigateFunction, id: string | null) {
+export function usePostCardRegister(navigate: NavigateFunction, id: string | null, from: string | null) {
   return useMutation({
     mutationFn: postCardRegister,
     onSuccess: (data) => {
       console.log("Card registration successful", data);
-      navigate(`/payment`, { state: { id: Number(id) } });
+      if (from === "/payment" && id) {
+        navigate(`/payment`, { state: { id: Number(id) } });
+      } else if (from === "/mypage") {
+        navigate(`/mypage`);
+      }
     },
     onError: (error) => {
       console.log("Card registration failed", error);

--- a/nonsoolmateClient/src/pages/payment/hooks/usePutCardUpdate.ts
+++ b/nonsoolmateClient/src/pages/payment/hooks/usePutCardUpdate.ts
@@ -2,12 +2,16 @@ import { useMutation } from "@tanstack/react-query";
 import { putCardUpdate } from "../api/putCardUpdate";
 import { NavigateFunction } from "react-router-dom";
 
-export function usePutCardUpdate(navigate: NavigateFunction, id: string | null) {
+export function usePutCardUpdate(navigate: NavigateFunction, id: string | null, from: string | null) {
   return useMutation({
     mutationFn: putCardUpdate,
     onSuccess: () => {
       console.log("Card update successful");
-      navigate(`/payment`, { state: { id: Number(id) } });
+      if (from === "/payment" && id) {
+        navigate(`/payment`, { state: { id: Number(id) } });
+      } else if (from === "/mypage") {
+        navigate(`/mypage`);
+      }
     },
     onError: (error) => {
       console.log("Card update failed", error);

--- a/nonsoolmateClient/src/pages/payment/index.tsx
+++ b/nonsoolmateClient/src/pages/payment/index.tsx
@@ -6,8 +6,8 @@ import RegisterLayout from "./components/register/RegisterLayout";
 import { media } from "style/responsiveStyle";
 import HomeHeader from "@pages/home/components/HomeHeader";
 import { useEffect, useState } from "react";
-import { loadTossPayments } from "@tosspayments/payment-sdk";
 import useGetCustomerInfo from "./hooks/useGetCustomerInfo";
+import { registerCard } from "@utils/registerCard";
 import { COUPON_NOT_REGISTER } from "constants/coupon";
 
 export default function Payment() {
@@ -61,28 +61,23 @@ export default function Payment() {
   }
 
   // -------- 카드 등록 로직
+  const from = location.pathname;
+  sessionStorage.setItem("from", from);
   const clientKey = `${import.meta.env.VITE_CLIENTKEY}`;
   const response = useGetCustomerInfo();
   if (!response) return <></>;
   const customerKey = response.customerKey;
 
-  function registerCard() {
-    loadTossPayments(clientKey).then((tossPayments) => {
-      tossPayments
-        .requestBillingAuth("카드", {
-          customerKey,
-          successUrl: `${window.location.origin}/success?id=${selectedPlan}`,
-          failUrl: window.location.origin + "/fail",
-        })
-        .catch((error) => {
-          if (error.code === "USER_CANCEL") {
-            // 사용자가 결제창을 닫았을 때
-          } else if (error.code === "INVALID_CARD_COMPANY") {
-            // 유효하지 않은 카드 코드에 대한 처리
-          }
-        });
+  function registerCardHandler() {
+    const from = sessionStorage.getItem("from");
+    registerCard({
+      clientKey,
+      customerKey,
+      selectedPlan,
+      from: from || "",
     });
   }
+
   // --------- 결제 에러 핸들링
   function showNotRegisterError(show: boolean) {
     setNotRegisterError(show);
@@ -105,7 +100,7 @@ export default function Payment() {
             isCouponOpen={modalStatus.isCouponOpen}
             couponTxt={couponTxt}
             dcInfo={dcInfo}
-            registerCard={registerCard}
+            registerCardHandler={registerCardHandler}
             activeCouponId={activeCouponId}
             handleActiveCouponId={handleActiveCouponId}
             notRegisterError={notRegisterError}

--- a/nonsoolmateClient/src/utils/registerCard.ts
+++ b/nonsoolmateClient/src/utils/registerCard.ts
@@ -1,0 +1,33 @@
+import { loadTossPayments } from "@tosspayments/payment-sdk";
+
+export function registerCard({
+  clientKey,
+  customerKey,
+  selectedPlan = null,
+  from,
+}: {
+  clientKey: string;
+  customerKey: string;
+  selectedPlan?: number | null;
+  from: string;
+}) {
+  loadTossPayments(clientKey).then((tossPayments) => {
+    const successUrl = selectedPlan
+      ? `${window.location.origin}/success?id=${selectedPlan}&&from=${from}`
+      : `${window.location.origin}/success?from=${from}`;
+
+    tossPayments
+      .requestBillingAuth("카드", {
+        customerKey,
+        successUrl,
+        failUrl: window.location.origin + "/fail",
+      })
+      .catch((error) => {
+        if (error.code === "USER_CANCEL") {
+          // 사용자가 결제창을 닫았을 때
+        } else if (error.code === "INVALID_CARD_COMPANY") {
+          // 유효하지 않은 카드 코드에 대한 처리
+        }
+      });
+  });
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #133 

## 📝 Done Task
- [x] 카드 등록 유틸 함수로 분리
- [x] 마이페이지에서의 카드 등록과 결제페이지에서의 카드 등록 구분  

## 🔎 PR Point
<!-- 리뷰어에게 내 코드를 설명해주세요. -->
기존에는 해당 컴포넌트에서 바로 카드 등록 함수를 작성, 사용하였기 때문에 매개변수가 필요 없었으나 재사용성을 위해 유틸 함수로 분리 후 매개변수 추가해주었습니다.
```typescript
export function registerCard({
  clientKey,
  customerKey,
  // 마이페이지에서는 selectedPlan이 없음
  selectedPlan = null,
  from,
}: {
  clientKey: string;
  customerKey: string;
  selectedPlan?: number | null;
  from: string;
}) {
...
}
```
마이페이지와 결제페이지에서의 카드 등록 로직은 거의 동일하지만 어디에서 카드 등록을 하냐에 따라 리다이렉트되는 페이지가 달라져서
세션 스토리지 이용해 from 에 해당 페이지 저장. 카드 등록 (변경) 버튼을 클릭했을 때 저장된 페이지를 불러왔습니다.
```typescript
  const from = location.pathname;
  sessionStorage.setItem("from", from);
```
```typescript
function registerCardHandler() {
    const from = sessionStorage.getItem("from");
    registerCard({
      clientKey,
      customerKey,
      from: from || "",
    });
  }
```
usePutCardUpdate와 usePostCardRegister에서 from에 따라 페이지 리다이렉트를 해주었습니다.
```typescript
 if (from === "/payment" && id) {
        navigate(`/payment`, { state: { id: Number(id) } });
      } else if (from === "/mypage") {
        navigate(`/mypage`);
      }     
```
mypage의 회원 정보가 아닌 멤버십 관리로 이동하게 수정할 예정입니다!
