### PR TITLE
[ QA ] 결제페이지 QA

### DIFF
--- a/src/pages/payment/components/register/RegisterLayout.tsx
+++ b/src/pages/payment/components/register/RegisterLayout.tsx
@@ -54,12 +54,12 @@ export default function RegisterLayout(props: RegisterLayoutProps) {
               {notRegisterError && item.title === "결제 수단" && <ErrorText>* 결제 수단을 등록해 주세요.</ErrorText>}
             </Title>
             <RegisterButton
-              button={item.buttonText}
-              onClick={item.buttonText === "쿠폰 사용" ? openCouponModal : registerCardHandler}
+              button={(item.title === "결제 수단" && response.cardInfo ? item.buttonText2 : item.buttonText1) || ""}
+              onClick={item.buttonText1 === "쿠폰 사용" ? openCouponModal : registerCardHandler}
             />
           </TitleContainer>
           <Content $payError={notRegisterError && item.title === "결제 수단"}>
-            {item.buttonText === "쿠폰 사용" ? (
+            {item.buttonText1 === "쿠폰 사용" ? (
               <Coupon>
                 <CouponTxt $couponTxt={couponTxt}>
                   {couponTxt !== COUPON_NOT_REGISTER && <SmallCouponIcon />}

--- a/src/pages/payment/core/registerText.ts
+++ b/src/pages/payment/core/registerText.ts
@@ -1,4 +1,4 @@
 export const REGISTER_TEXT = [
-  { title: "쿠폰 사용", buttonText: "쿠폰 사용", content: "등록된 쿠폰이 없습니다." },
-  { title: "결제 수단", buttonText: "카드 등록", content: "등록된 카드가 없습니다." },
+  { title: "쿠폰 사용", buttonText1: "쿠폰 사용", content: "등록된 쿠폰이 없습니다." },
+  { title: "결제 수단", buttonText1: "카드 등록", buttonText2: "카드 변경", content: "등록된 카드가 없습니다." },
 ];

--- a/src/pages/payment/index.tsx
+++ b/src/pages/payment/index.tsx
@@ -88,9 +88,9 @@ export default function Payment() {
   }
 
   return (
-    <>
+    <PaymentContainer>
       <HomeHeader />
-      <PaymentContainer>
+      <PaymentWrapper>
         <PaymentLeftContainer>
           <Title>정기결제</Title>
           <OrderInfo id={initialId} selectedPlan={selectedPlan} onPlanChange={handlePlanChange} />
@@ -123,17 +123,25 @@ export default function Payment() {
           showAlreadyPaidError={showAlreadyPaidError}
           dcInfo={dcInfo}
         />
-      </PaymentContainer>
-    </>
+      </PaymentWrapper>
+    </PaymentContainer>
   );
 }
 
 const PaymentContainer = styled.section`
   display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+`;
+const PaymentWrapper = styled.div`
+  display: flex;
   flex-wrap: nowrap;
   gap: 2.4rem;
   align-self: flex-start;
-  margin: 4.8rem 21.5rem;
+  width: 100%;
+  padding: 4.8rem 21.5rem;
+
   ${media.tablet} {
     flex-direction: column;
     gap: 5.6rem;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #153 

## 📝 Done Task
- [x] 결제 페이지 아래의 여백 추가
  - 제 맥북에서는 여백이 잘 보이는데 삼성 노트북에서 볼 때 여백이 없어서 태그로 하나 더 감싸서 수정했습니다!
- [x] 이미 등록된 카드가 있을 때 카드 등록에서 카드 변경으로 워딩 수정

## 📸 Screenshot

결제 페이지의 아래 여백 및 등록된 카드 있을 때 버튼 워딩 카드 변경 확인
<img width="1336" alt="스크린샷 2024-10-28 오후 1 12 51" src="https://github.com/user-attachments/assets/ecf1a0fd-825d-4a9b-a3b4-490b34d57f9d">

