### PR TITLE
[ QA ] 마이페이지 QA 해결

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -37,7 +37,7 @@ const Background = styled.div`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1;
+  z-index: 3;
   width: 100%;
   height: 100%;
   background-color: rgb(0 0 0 / 50%);

--- a/src/pages/mypage/components/MemberInfo.tsx
+++ b/src/pages/mypage/components/MemberInfo.tsx
@@ -52,11 +52,12 @@ export default function MemberInfo() {
     const isFormValid = isNameValid && isEmailValid && isPhoneNumberValid && isBirthdayValid;
 
     setIsSubmitted(true);
-    dispatch({ type: "SHOW_MODAL", variant: "confirm" });
 
     if (!isFormValid) {
       return;
     }
+
+    dispatch({ type: "SHOW_MODAL", variant: "confirm" });
 
     editMemberInfo({
       name: input.name,

--- a/src/pages/mypage/components/Mentor.tsx
+++ b/src/pages/mypage/components/Mentor.tsx
@@ -3,6 +3,7 @@ import Button from "@components/button/Button";
 import UnivChip from "@components/univChip/UnivChip";
 import useGetName from "@pages/home/hooks/useGetName";
 import { useGetMentor } from "@pages/mypage/hooks/useGetMentor";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import useGetMembership from "../hooks/useGetMembership";
 
@@ -11,6 +12,8 @@ export default function Mentor() {
   const { data } = useGetMentor();
   const { data: membershipData } = useGetMembership();
 
+  const navigate = useNavigate();
+
   return (
     <MentorWrapper>
       <Title>담당 선생님</Title>
@@ -18,7 +21,7 @@ export default function Mentor() {
         <NullMentorWrapper>
           <NullMentorContainer>
             <Content style={{ margin: 0 }}>아직 배정받은 선생님이 없어요.</Content>
-            <Button>선생님 배정 받기</Button>
+            <Button onClick={() => navigate("/membership")}>선생님 배정 받기</Button>
           </NullMentorContainer>
         </NullMentorWrapper>
       ) : data?.isMatched ? (

--- a/src/pages/mypage/hooks/useMemberInfo.ts
+++ b/src/pages/mypage/hooks/useMemberInfo.ts
@@ -47,6 +47,12 @@ export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
     if (value.length == 0) {
       return ERROR_MESSAGE.NAME_EMPTY;
     }
+
+    const koreanRegex = /^[가-힣]+$/;
+
+    if (!koreanRegex.test(value)) {
+      return ERROR_MESSAGE.LANGUAGE;
+    }
   }, []);
 
   const validateEmail = useCallback((value: string) => {

--- a/src/pages/mypage/hooks/useMemberInfo.ts
+++ b/src/pages/mypage/hooks/useMemberInfo.ts
@@ -44,7 +44,7 @@ export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
   }, []);
 
   const validateName = useCallback((value: string) => {
-    const koreanRegex = /^[가-힣]+$/;
+    const koreanRegex = /^[ㄱ-ㅎ가-힣]+$/;
 
     if (value.length == 0) {
       return ERROR_MESSAGE.NAME_EMPTY;

--- a/src/pages/mypage/hooks/useMemberInfo.ts
+++ b/src/pages/mypage/hooks/useMemberInfo.ts
@@ -44,11 +44,11 @@ export default function useMemberInfo(response: AxiosResponse<DataTypes>) {
   }, []);
 
   const validateName = useCallback((value: string) => {
+    const koreanRegex = /^[가-힣]+$/;
+
     if (value.length == 0) {
       return ERROR_MESSAGE.NAME_EMPTY;
     }
-
-    const koreanRegex = /^[가-힣]+$/;
 
     if (!koreanRegex.test(value)) {
       return ERROR_MESSAGE.LANGUAGE;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #176 

## 📝 Done Task
- [x] 선생님 배정받기 버튼 누르면 멤버십 페이지 라우팅
- [x] 회원정보 - 이름은 한글만 입력 가능

## 🔎 PR Point
<!-- 리뷰어에게 내 코드를 설명해주세요. -->
이름 input validate를 하나 더 추가해줬습니다.
```tsx
  const validateName = useCallback((value: string) => {
    if (value.length == 0) {
      return ERROR_MESSAGE.NAME_EMPTY;
    }

    const koreanRegex = /^[가-힣]+$/; // 추가

    if (!koreanRegex.test(value)) {
      return ERROR_MESSAGE.LANGUAGE;
    }
  }, []);
```
또한 MemberInfo에서 validate를 먼저 검사하고 통과하지 못할경우 리턴하는 로직을 모달 호출 함수보다 먼저 작성하여 validate 하지 못하는 경우 저장 모달이 띄워지지 않도록 수정해줬습니다.


## 💣 Trouble Shooting

## 📸 Screenshot


https://github.com/user-attachments/assets/0749e566-836d-42dc-8d75-c84654788783




