### PR TITLE
[ QA ] 논술 합격 인증 마크 태그 필드 삭제에 따른 api 수정 및 텍스트 삽입

### DIFF
--- a/src/pages/mypage/api/getMentor.ts
+++ b/src/pages/mypage/api/getMentor.ts
@@ -14,13 +14,6 @@ export interface MentorDataTypes {
       universityImageUrl: string;
     },
   ];
-  tags: [
-    {
-      tagId: number;
-      tagName: string;
-      tagImageUrl: string;
-    },
-  ];
 }
 
 export async function getMentor() {

--- a/src/pages/mypage/components/Mentor.tsx
+++ b/src/pages/mypage/components/Mentor.tsx
@@ -33,13 +33,12 @@ export default function Mentor() {
 
               <MentorProfileBox>
                 <Name>{data?.teacherName} 선생님</Name>
-                {data.isCertified &&
-                  data.tags.map((tag) => (
-                    <Badge key={tag.tagId}>
-                      <PassIc />
-                      {tag.tagName}
-                    </Badge>
-                  ))}
+                {data.isCertified && (
+                  <Badge>
+                    <PassIc />
+                    논술 합격 인증
+                  </Badge>
+                )}
               </MentorProfileBox>
               <ButtonBox>
                 {data.qnaLink && membershipData && membershipData?.membershipName !== "베이직 플랜" && (


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 ! -->

## 🔗 Related Issue
- close #180 

## 🔎 PR Point
<!-- 리뷰어에게 내 코드를 설명해주세요. -->
논술 합격 인증 마크 태그 필드 삭제에 따른 api 수정 후 tags에서 map으로 데이터 뿌려주는 형식에서 텍스트 삽입으로 변경했습니다!
